### PR TITLE
Move id arg to def in DefineType

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -6,7 +6,8 @@ Custom Types provide a way to introduce reusable, sharable types to Apps.
 Types can be defined with the top level `DefineType` export. Below is an example of setting up a Custom Type object that usable for incidents.
 
 ```ts
-const IncidentType = DefineType('incident', {
+const IncidentType = DefineType({
+  callback_id: 'incident',
   title: "Incident Ticket",
   description: "Use this to enter an Incident Ticket",
   type: Schema.types.object,

--- a/docs/types.md
+++ b/docs/types.md
@@ -7,7 +7,7 @@ Types can be defined with the top level `DefineType` export. Below is an example
 
 ```ts
 const IncidentType = DefineType({
-  callback_id: 'incident',
+  callback_id: "incident",
   title: "Incident Ticket",
   description: "Use this to enter an Incident Ticket",
   type: Schema.types.object,

--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -48,16 +48,19 @@ Deno.test("Manifest() automatically registers types used by function input and o
   const outputTypeId = "test_output_type";
   const stringTypeId = "test_string_type";
 
-  const CustomStringType = DefineType(stringTypeId, {
+  const CustomStringType = DefineType({
+    callback_id: stringTypeId,
     type: Schema.types.string,
   });
 
-  const CustomInputType = DefineType(inputTypeId, {
+  const CustomInputType = DefineType({
+    callback_id: inputTypeId,
     type: Schema.types.object,
     properties: { aString: { type: CustomStringType } },
   });
 
-  const CustomOutputType = DefineType(outputTypeId, {
+  const CustomOutputType = DefineType({
+    callback_id: outputTypeId,
     type: Schema.types.boolean,
   });
 
@@ -104,18 +107,21 @@ Deno.test("Manifest() automatically registers types referenced by other types", 
   const stringTypeId = "test_string_type";
   const arrayTypeId = "test_array_type";
 
-  const StringType = DefineType(stringTypeId, {
+  const StringType = DefineType({
+    callback_id: stringTypeId,
     type: Schema.types.string,
   });
 
-  const ObjectType = DefineType(objectTypeId, {
+  const ObjectType = DefineType({
+    callback_id: objectTypeId,
     type: Schema.types.object,
     properties: {
       aString: { type: StringType },
     },
   });
 
-  const ArrayType = DefineType(arrayTypeId, {
+  const ArrayType = DefineType({
+    callback_id: arrayTypeId,
     type: Schema.types.array,
     items: {
       type: ObjectType,
@@ -145,11 +151,13 @@ Deno.test("SlackManifest() registration functions don't allow duplicates", () =>
   const objectTypeId = "test_object_type";
   const stringTypeId = "test_string_type";
 
-  const CustomStringType = DefineType(stringTypeId, {
+  const CustomStringType = DefineType({
+    callback_id: stringTypeId,
     type: Schema.types.string,
   });
 
-  const CustomObjectType = DefineType(objectTypeId, {
+  const CustomObjectType = DefineType({
+    callback_id: objectTypeId,
     type: Schema.types.object,
     properties: {
       aString: {

--- a/src/parameters/parameter-variable_test.ts
+++ b/src/parameters/parameter-variable_test.ts
@@ -72,7 +72,8 @@ Deno.test("ParameterVariable array of strings", () => {
 });
 
 Deno.test("ParameterVariable using CustomType string", () => {
-  const customType = DefineType("customTypeString", {
+  const customType = DefineType({
+    callback_id: "customTypeString",
     type: SchemaTypes.string,
   });
   const param = ParameterVariable("", "myCustomTypeString", {
@@ -83,7 +84,8 @@ Deno.test("ParameterVariable using CustomType string", () => {
 });
 
 Deno.test("ParameterVariable using Custom Type typed object", () => {
-  const customType = DefineType("customType", {
+  const customType = DefineType({
+    callback_id: "customType",
     type: SchemaTypes.object,
     properties: {
       aString: {
@@ -100,7 +102,8 @@ Deno.test("ParameterVariable using Custom Type typed object", () => {
 });
 
 Deno.test("ParameterVariable using Custom Type untyped object", () => {
-  const customType = DefineType("customTypeObject", {
+  const customType = DefineType({
+    callback_id: "customTypeObject",
     type: SchemaTypes.object,
   });
   const param = ParameterVariable("", "myCustomTypeObject", {
@@ -114,7 +117,8 @@ Deno.test("ParameterVariable using Custom Type untyped object", () => {
 });
 
 Deno.test("ParameterVariable using Custom Type array", () => {
-  const customType = DefineType("customTypeArray", {
+  const customType = DefineType({
+    callback_id: "customTypeArray",
     type: SchemaTypes.array,
   });
   const param = ParameterVariable("", "myCustomTypeArray", {
@@ -125,11 +129,13 @@ Deno.test("ParameterVariable using Custom Type array", () => {
 });
 
 Deno.test("ParameterVariable using Custom Type object referencing another Custom Type", () => {
-  const StringType = DefineType("stringType", {
+  const StringType = DefineType({
+    callback_id: "stringType",
     type: SchemaTypes.string,
     minLength: 2,
   });
-  const customType = DefineType("customTypeWithCustomType", {
+  const customType = DefineType({
+    callback_id: "customTypeWithCustomType",
     type: SchemaTypes.object,
     properties: {
       customType: {
@@ -146,7 +152,8 @@ Deno.test("ParameterVariable using Custom Type object referencing another Custom
 });
 
 Deno.test("ParameterVariable typed object with Custom Type property", () => {
-  const StringType = DefineType("stringType", {
+  const StringType = DefineType({
+    callback_id: "stringType",
     type: SchemaTypes.string,
     minLength: 2,
   });

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -1,24 +1,22 @@
 import { SlackManifest } from "../manifest.ts";
-import { TypedParameterDefinition } from "../parameters/types.ts";
-import { ICustomType } from "./types.ts";
+import { CustomTypeDefinition, ICustomType } from "./types.ts";
 
-export const DefineType = <Def extends TypedParameterDefinition>(
-  id: string,
+export const DefineType = <Def extends CustomTypeDefinition>(
   definition: Def,
 ) => {
-  return new CustomType(id, definition);
+  return new CustomType(definition);
 };
 
-export class CustomType<Def extends TypedParameterDefinition>
+export class CustomType<Def extends CustomTypeDefinition>
   implements ICustomType {
+  public id: string;
   public title: string | undefined;
   public description: string | undefined;
 
   constructor(
-    public id: string,
     public definition: Def,
   ) {
-    this.id = id;
+    this.id = definition.callback_id;
     this.definition = definition;
     this.description = definition.description;
     this.title = definition.title;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,9 +1,13 @@
 import { TypedParameterDefinition } from "../parameters/types.ts";
 import { SlackManifest } from "../manifest.ts";
 
+export type CustomTypeDefinition =
+  & { callback_id: string }
+  & TypedParameterDefinition;
+
 export interface ICustomType {
   id: string;
-  definition: TypedParameterDefinition;
+  definition: CustomTypeDefinition;
   description?: string;
   registerParameterTypes: (manifest: SlackManifest) => void;
 }


### PR DESCRIPTION
# Summary

Move the type `id` into the `definition` to match the change to `DefineFunction`