### PR TITLE
Change the supported types for reignite

### DIFF
--- a/src/functions/functions_test.ts
+++ b/src/functions/functions_test.ts
@@ -25,28 +25,32 @@ Deno.test("Function with required params", () => {
     title: "All Types Function",
     source_file: "functions/example.ts",
     input_parameters: {
-      required: ["myString", "myNumber"],
+      required: ["myString" /* , "myNumber" */],
       properties: {
         myString: {
           type: Schema.types.string,
           title: "My string",
           description: "a really neat value",
         },
-        integer: {
-          type: Schema.types.integer,
-          description: "integer",
+        myBoolean: {
+          type: Schema.types.boolean,
+          title: "My boolean",
         },
-        myNumber: {
-          type: Schema.types.number,
-          description: "number",
-        },
+        // integer: {
+        //   type: Schema.types.integer,
+        //   description: "integer",
+        // },
+        // myNumber: {
+        //   type: Schema.types.number,
+        //   description: "number",
+        // },
       },
     },
     output_parameters: {
       required: ["out"],
       properties: {
         out: {
-          type: Schema.types.integer,
+          type: Schema.types.string,
         },
       },
     },
@@ -54,7 +58,7 @@ Deno.test("Function with required params", () => {
 
   assertEquals(AllTypesFunction.definition.input_parameters?.required, [
     "myString",
-    "myNumber",
+    // "myNumber",
   ]);
   assertEquals(AllTypesFunction.definition.output_parameters?.required, [
     "out",

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -6,7 +6,7 @@ import {
 } from "../parameters/mod.ts";
 import {
   TypedArrayParameterDefinition,
-  TypedObjectParameterDefinition,
+  // TypedObjectParameterDefinition,
 } from "../parameters/types.ts";
 import SchemaTypes from "../schema/schema_types.ts";
 import SlackSchemaTypes from "../schema/slack/schema_types.ts";
@@ -73,40 +73,40 @@ export type FunctionContext<
 
 type FunctionInputRuntimeType<Param extends ParameterDefinition> =
   Param["type"] extends typeof SchemaTypes.string ? string
-    : Param["type"] extends
-      | typeof SchemaTypes.integer
-      | typeof SchemaTypes.number ? number
-    : Param["type"] extends typeof SchemaTypes.boolean ? boolean
+    : // : Param["type"] extends
+    //   | typeof SchemaTypes.integer
+    //   | typeof SchemaTypes.number ? number
+    Param["type"] extends typeof SchemaTypes.boolean ? boolean
     : Param["type"] extends typeof SchemaTypes.array
       ? Param extends TypedArrayParameterDefinition
         ? TypedArrayFunctionInputRuntimeType<Param>
       : UnknownRuntimeType[]
-    : Param["type"] extends typeof SchemaTypes.object
-      ? Param extends TypedObjectParameterDefinition
-        ? TypedObjectFunctionInputRuntimeType<Param>
-      : UnknownRuntimeType
-    : // TODO: Look at moving these slack runtime type declarations into the slack type definitions once we have DefineType and can use it there
+    : // : Param["type"] extends typeof SchemaTypes.object
+    //   ? Param extends TypedObjectParameterDefinition
+    //     ? TypedObjectFunctionInputRuntimeType<Param>
+    //   : UnknownRuntimeType
+    // TODO: Look at moving these slack runtime type declarations into the slack type definitions once we have DefineType and can use it there
     Param["type"] extends
       | typeof SlackSchemaTypes.user_id
-      | typeof SlackSchemaTypes.channel_id
-      | typeof SlackSchemaTypes.usergroup_id ? string
-    : Param["type"] extends typeof SlackSchemaTypes.timestamp ? number
-    : UnknownRuntimeType;
+      | typeof SlackSchemaTypes.channel_id ? // | typeof SlackSchemaTypes.usergroup_id
+    string
+    : // : Param["type"] extends typeof SlackSchemaTypes.timestamp ? number
+    UnknownRuntimeType;
 
 // deno-lint-ignore no-explicit-any
 type UnknownRuntimeType = any;
 
-type TypedObjectFunctionInputRuntimeType<
-  Param extends TypedObjectParameterDefinition,
-> =
-  & {
-    [k in keyof Param["properties"]]: FunctionInputRuntimeType<
-      Param["properties"][k]
-    >;
-  }
-  & {
-    [key: string]: UnknownRuntimeType;
-  };
+// type TypedObjectFunctionInputRuntimeType<
+//   Param extends TypedObjectParameterDefinition,
+// > =
+//   & {
+//     [k in keyof Param["properties"]]: FunctionInputRuntimeType<
+//       Param["properties"][k]
+//     >;
+//   }
+//   & {
+//     [key: string]: UnknownRuntimeType;
+//   };
 
 type TypedArrayFunctionInputRuntimeType<
   Param extends TypedArrayParameterDefinition,

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -1,12 +1,12 @@
-import SchemaTypes from "../schema/schema_types.ts";
+// import SchemaTypes from "../schema/schema_types.ts";
 import type {
   CustomTypeParameterDefinition,
-  TypedObjectParameterDefinition,
+  // TypedObjectParameterDefinition,
   TypedParameterDefinition,
-  UntypedObjectParameterDefinition,
+  // UntypedObjectParameterDefinition,
 } from "./types.ts";
 import { ParamReference } from "./param.ts";
-import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
+// import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
 
 export type ParameterDefinition = TypedParameterDefinition;
 
@@ -31,11 +31,11 @@ export type ParameterPropertiesDefinition<
 export type ParameterVariableType<Def extends ParameterDefinition> = Def extends
   CustomTypeParameterDefinition // If the ParameterVariable is a Custom type, use it's definition instead
   ? ParameterVariableType<Def["type"]["definition"]>
-  : Def extends TypedObjectParameterDefinition // If the ParameterVariable is of type object, allow access to the object's properties
-    ? ObjectParameterVariableType<Def>
-  : Def extends UntypedObjectParameterDefinition
-    ? UntypedObjectParameterVariableType
-  : SingleParameterVariable;
+  : // : Def extends TypedObjectParameterDefinition // If the ParameterVariable is of type object, allow access to the object's properties
+  //   ? ObjectParameterVariableType<Def>
+  // : Def extends UntypedObjectParameterDefinition
+  //   ? UntypedObjectParameterVariableType
+  SingleParameterVariable;
 
 // deno-lint-ignore ban-types
 type SingleParameterVariable = {};
@@ -43,23 +43,23 @@ type SingleParameterVariable = {};
 // deno-lint-ignore no-explicit-any
 type UntypedObjectParameterVariableType = any;
 
-type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
-  {
-    [name in keyof Def["properties"]]: ParameterVariableType<
-      Def["properties"][name]
-    >;
-  };
+// type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
+//   {
+//     [name in keyof Def["properties"]]: ParameterVariableType<
+//       Def["properties"][name]
+//     >;
+//   };
 
 // If additionalProperties is set to true, allow access to any key
 // Otherwise, only allow keys provided through use of properties
-type ObjectParameterVariableType<Def extends TypedObjectParameterDefinition> =
-  Def["additionalProperties"] extends true ? 
-    & ObjectParameterPropertyTypes<Def>
-    & {
-      // deno-lint-ignore no-explicit-any
-      [key: string]: any;
-    }
-    : ObjectParameterPropertyTypes<Def>;
+// type ObjectParameterVariableType<Def extends TypedObjectParameterDefinition> =
+//   Def["additionalProperties"] extends true ?
+//     & ObjectParameterPropertyTypes<Def>
+//     & {
+//       // deno-lint-ignore no-explicit-any
+//       [key: string]: any;
+//     }
+//     : ObjectParameterPropertyTypes<Def>;
 
 export const ParameterVariable = <P extends ParameterDefinition>(
   namespace: string,
@@ -75,16 +75,16 @@ export const ParameterVariable = <P extends ParameterDefinition>(
       paramName,
       definition.type.definition,
     ) as ParameterVariableType<P>;
-  } else if (definition.type === SchemaTypes.object) {
-    if ("properties" in definition) {
-      param = CreateTypedObjectParameterVariable(
-        namespace,
-        paramName,
-        definition,
-      ) as ParameterVariableType<P>;
-    } else {
-      param = CreateUntypedObjectParameterVariable(namespace, paramName);
-    }
+    // } else if (definition.type === SchemaTypes.object) {
+    //   if ("properties" in definition) {
+    //     param = CreateTypedObjectParameterVariable(
+    //       namespace,
+    //       paramName,
+    //       definition,
+    //     ) as ParameterVariableType<P>;
+    //   } else {
+    //     param = CreateUntypedObjectParameterVariable(namespace, paramName);
+    //   }
   } else {
     param = CreateSingleParameterVariable(
       namespace,
@@ -95,47 +95,47 @@ export const ParameterVariable = <P extends ParameterDefinition>(
   return param as ParameterVariableType<P>;
 };
 
-const CreateTypedObjectParameterVariable = <
-  P extends TypedObjectParameterDefinition,
->(
-  namespace: string,
-  paramName: string,
-  definition: P,
-): ObjectParameterVariableType<P> => {
-  const ns = namespace ? `${namespace}.` : "";
-  const pathReference = `${ns}${paramName}`;
-  const param = ParamReference(pathReference);
+// const CreateTypedObjectParameterVariable = <
+//   P extends TypedObjectParameterDefinition,
+// >(
+//   namespace: string,
+//   paramName: string,
+//   definition: P,
+// ): ObjectParameterVariableType<P> => {
+//   const ns = namespace ? `${namespace}.` : "";
+//   const pathReference = `${ns}${paramName}`;
+//   const param = ParamReference(pathReference);
 
-  for (
-    const [propName, propDefinition] of Object.entries(
-      definition.properties || {},
-    )
-  ) {
-    param[propName as string] = ParameterVariable(
-      pathReference,
-      propName,
-      propDefinition,
-    );
-  }
+//   for (
+//     const [propName, propDefinition] of Object.entries(
+//       definition.properties || {},
+//     )
+//   ) {
+//     param[propName as string] = ParameterVariable(
+//       pathReference,
+//       propName,
+//       propDefinition,
+//     );
+//   }
 
-  // We wrap the typed object parameter w/ an untyped proxy to allow indexing into additional properties
-  return WithUntypedObjectProxy(
-    param,
-    namespace,
-    paramName,
-  ) as ObjectParameterVariableType<P>;
-};
+//   // We wrap the typed object parameter w/ an untyped proxy to allow indexing into additional properties
+//   return WithUntypedObjectProxy(
+//     param,
+//     namespace,
+//     paramName,
+//   ) as ObjectParameterVariableType<P>;
+// };
 
-const CreateUntypedObjectParameterVariable = (
-  namespace: string,
-  paramName: string,
-): UntypedObjectParameterVariableType => {
-  return WithUntypedObjectProxy(
-    {},
-    namespace,
-    paramName,
-  ) as UntypedObjectParameterVariableType;
-};
+// const CreateUntypedObjectParameterVariable = (
+//   namespace: string,
+//   paramName: string,
+// ): UntypedObjectParameterVariableType => {
+//   return WithUntypedObjectProxy(
+//     {},
+//     namespace,
+//     paramName,
+//   ) as UntypedObjectParameterVariableType;
+// };
 
 const CreateSingleParameterVariable = (
   namespace: string,

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -40,8 +40,8 @@ export type ParameterVariableType<Def extends ParameterDefinition> = Def extends
 // deno-lint-ignore ban-types
 type SingleParameterVariable = {};
 
-// deno-lint-ignore no-explicit-any
-type UntypedObjectParameterVariableType = any;
+// // deno-lint-ignore no-explicit-any
+// type UntypedObjectParameterVariableType = any;
 
 // type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
 //   {

--- a/src/parameters/parameter-variable_test.ts
+++ b/src/parameters/parameter-variable_test.ts
@@ -11,54 +11,54 @@ Deno.test("ParameterVariable string", () => {
   assertEquals(`${param}`, "{{incident_name}}");
 });
 
-Deno.test("ParameterVariable typed object", () => {
-  const param = ParameterVariable("", "incident", {
-    type: SchemaTypes.object,
-    properties: {
-      id: {
-        type: SchemaTypes.integer,
-      },
-      name: {
-        type: SchemaTypes.string,
-      },
-    },
-  });
+// Deno.test("ParameterVariable typed object", () => {
+//   const param = ParameterVariable("", "incident", {
+//     type: SchemaTypes.object,
+//     properties: {
+//       id: {
+//         type: SchemaTypes.integer,
+//       },
+//       name: {
+//         type: SchemaTypes.string,
+//       },
+//     },
+//   });
 
-  assertEquals(`${param}`, "{{incident}}");
-  assertEquals(`${param.id}`, "{{incident.id}}");
-  assertEquals(`${param.name}`, "{{incident.name}}");
-});
+//   assertEquals(`${param}`, "{{incident}}");
+//   assertEquals(`${param.id}`, "{{incident.id}}");
+//   assertEquals(`${param.name}`, "{{incident.name}}");
+// });
 
-Deno.test("ParameterVariable typed object with additional properties", () => {
-  const param = ParameterVariable("", "incident", {
-    type: SchemaTypes.object,
-    properties: {
-      id: {
-        type: SchemaTypes.integer,
-      },
-      name: {
-        type: SchemaTypes.string,
-      },
-    },
-    additionalProperties: true,
-  });
+// Deno.test("ParameterVariable typed object with additional properties", () => {
+//   const param = ParameterVariable("", "incident", {
+//     type: SchemaTypes.object,
+//     properties: {
+//       id: {
+//         type: SchemaTypes.integer,
+//       },
+//       name: {
+//         type: SchemaTypes.string,
+//       },
+//     },
+//     additionalProperties: true,
+//   });
 
-  assertEquals(`${param}`, "{{incident}}");
-  assertEquals(`${param.id}`, "{{incident.id}}");
-  assertEquals(`${param.name}`, "{{incident.name}}");
-  assertEquals(`${param.foo.bar}`, "{{incident.foo.bar}}");
-});
+//   assertEquals(`${param}`, "{{incident}}");
+//   assertEquals(`${param.id}`, "{{incident.id}}");
+//   assertEquals(`${param.name}`, "{{incident.name}}");
+//   assertEquals(`${param.foo.bar}`, "{{incident.foo.bar}}");
+// });
 
-Deno.test("ParameterVariable untyped object", () => {
-  const param = ParameterVariable("", "incident", {
-    type: SchemaTypes.object,
-  });
+// Deno.test("ParameterVariable untyped object", () => {
+//   const param = ParameterVariable("", "incident", {
+//     type: SchemaTypes.object,
+//   });
 
-  assertEquals(`${param}`, "{{incident}}");
-  assertEquals(`${param.id}`, "{{incident.id}}");
-  assertEquals(`${param.name}`, "{{incident.name}}");
-  assertEquals(`${param.name.foo.bar}`, "{{incident.name.foo.bar}}");
-});
+//   assertEquals(`${param}`, "{{incident}}");
+//   assertEquals(`${param.id}`, "{{incident.id}}");
+//   assertEquals(`${param.name}`, "{{incident.name}}");
+//   assertEquals(`${param.name.foo.bar}`, "{{incident.name.foo.bar}}");
+// });
 
 Deno.test("ParameterVariable array of strings", () => {
   const param = ParameterVariable("", "myArray", {
@@ -83,38 +83,38 @@ Deno.test("ParameterVariable using CustomType string", () => {
   assertEquals(`${param}`, "{{myCustomTypeString}}");
 });
 
-Deno.test("ParameterVariable using Custom Type typed object", () => {
-  const customType = DefineType({
-    callback_id: "customType",
-    type: SchemaTypes.object,
-    properties: {
-      aString: {
-        type: SchemaTypes.string,
-      },
-    },
-  });
-  const param = ParameterVariable("", "myCustomType", {
-    type: customType,
-  });
+// Deno.test("ParameterVariable using Custom Type typed object", () => {
+//   const customType = DefineType({
+//     callback_id: "customType",
+//     type: SchemaTypes.object,
+//     properties: {
+//       aString: {
+//         type: SchemaTypes.string,
+//       },
+//     },
+//   });
+//   const param = ParameterVariable("", "myCustomType", {
+//     type: customType,
+//   });
 
-  assertEquals(`${param}`, "{{myCustomType}}");
-  assertEquals(`${param.aString}`, "{{myCustomType.aString}}");
-});
+//   assertEquals(`${param}`, "{{myCustomType}}");
+//   assertEquals(`${param.aString}`, "{{myCustomType.aString}}");
+// });
 
-Deno.test("ParameterVariable using Custom Type untyped object", () => {
-  const customType = DefineType({
-    callback_id: "customTypeObject",
-    type: SchemaTypes.object,
-  });
-  const param = ParameterVariable("", "myCustomTypeObject", {
-    type: customType,
-  });
+// Deno.test("ParameterVariable using Custom Type untyped object", () => {
+//   const customType = DefineType({
+//     callback_id: "customTypeObject",
+//     type: SchemaTypes.object,
+//   });
+//   const param = ParameterVariable("", "myCustomTypeObject", {
+//     type: customType,
+//   });
 
-  assertEquals(`${param}`, "{{myCustomTypeObject}}");
-  assertEquals(`${param.foo}`, "{{myCustomTypeObject.foo}}");
-  assertEquals(`${param.foo.bar}`, "{{myCustomTypeObject.foo.bar}}");
-  assertEquals(`${param.foo.bar.baz}`, "{{myCustomTypeObject.foo.bar.baz}}");
-});
+//   assertEquals(`${param}`, "{{myCustomTypeObject}}");
+//   assertEquals(`${param.foo}`, "{{myCustomTypeObject.foo}}");
+//   assertEquals(`${param.foo.bar}`, "{{myCustomTypeObject.foo.bar}}");
+//   assertEquals(`${param.foo.bar.baz}`, "{{myCustomTypeObject.foo.bar.baz}}");
+// });
 
 Deno.test("ParameterVariable using Custom Type array", () => {
   const customType = DefineType({
@@ -128,45 +128,45 @@ Deno.test("ParameterVariable using Custom Type array", () => {
   assertEquals(`${param}`, "{{myCustomTypeArray}}");
 });
 
-Deno.test("ParameterVariable using Custom Type object referencing another Custom Type", () => {
-  const StringType = DefineType({
-    callback_id: "stringType",
-    type: SchemaTypes.string,
-    minLength: 2,
-  });
-  const customType = DefineType({
-    callback_id: "customTypeWithCustomType",
-    type: SchemaTypes.object,
-    properties: {
-      customType: {
-        type: StringType,
-      },
-    },
-  });
-  const param = ParameterVariable("", "myNestedCustomType", {
-    type: customType,
-  });
+// Deno.test("ParameterVariable using Custom Type object referencing another Custom Type", () => {
+//   const StringType = DefineType({
+//     callback_id: "stringType",
+//     type: SchemaTypes.string,
+//     minLength: 2,
+//   });
+//   const customType = DefineType({
+//     callback_id: "customTypeWithCustomType",
+//     type: SchemaTypes.object,
+//     properties: {
+//       customType: {
+//         type: StringType,
+//       },
+//     },
+//   });
+//   const param = ParameterVariable("", "myNestedCustomType", {
+//     type: customType,
+//   });
 
-  assertEquals(`${param}`, "{{myNestedCustomType}}");
-  assertEquals(`${param.customType}`, "{{myNestedCustomType.customType}}");
-});
+//   assertEquals(`${param}`, "{{myNestedCustomType}}");
+//   assertEquals(`${param.customType}`, "{{myNestedCustomType.customType}}");
+// });
 
-Deno.test("ParameterVariable typed object with Custom Type property", () => {
-  const StringType = DefineType({
-    callback_id: "stringType",
-    type: SchemaTypes.string,
-    minLength: 2,
-  });
+// Deno.test("ParameterVariable typed object with Custom Type property", () => {
+//   const StringType = DefineType({
+//     callback_id: "stringType",
+//     type: SchemaTypes.string,
+//     minLength: 2,
+//   });
 
-  const param = ParameterVariable("", "myObjectParam", {
-    type: SchemaTypes.object,
-    properties: {
-      aString: {
-        type: StringType,
-      },
-    },
-  });
+//   const param = ParameterVariable("", "myObjectParam", {
+//     type: SchemaTypes.object,
+//     properties: {
+//       aString: {
+//         type: StringType,
+//       },
+//     },
+//   });
 
-  assertEquals(`${param}`, "{{myObjectParam}}");
-  assertEquals(`${param.aString}`, "{{myObjectParam.aString}}");
-});
+//   assertEquals(`${param}`, "{{myObjectParam}}");
+//   assertEquals(`${param.aString}`, "{{myObjectParam.aString}}");
+// });

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -4,16 +4,16 @@ import { ICustomType } from "../types/types.ts";
 export type PrimitiveParameterDefinition =
   | BooleanParameterDefinition
   | StringParameterDefinition
-  | NumberParameterDefinition
-  | IntegerParameterDefinition
+  // | NumberParameterDefinition
+  // | IntegerParameterDefinition
   | BaseParameterDefinition<AllValues>
   | UntypedArrayParameterDefinition
   | TypedArrayParameterDefinition;
 
 export type TypedParameterDefinition =
-  | TypedObjectParameterDefinition
-  | UntypedObjectParameterDefinition
-  | PrimitiveParameterDefinition;
+  // | TypedObjectParameterDefinition
+  // | UntypedObjectParameterDefinition
+  PrimitiveParameterDefinition;
 
 export type CustomTypeParameterDefinition =
   & BaseParameterDefinition<AllValues>
@@ -35,25 +35,25 @@ type BaseParameterDefinition<T> = {
   examples?: T[];
 };
 
-export type UntypedObjectParameterDefinition =
-  & BaseParameterDefinition<ObjectValue>
-  & {
-    type: typeof SchemaTypes.object;
-  };
+// export type UntypedObjectParameterDefinition =
+//   & BaseParameterDefinition<ObjectValue>
+//   & {
+//     type: typeof SchemaTypes.object;
+//   };
 
 // TODO: Required field should be limited to the names(key) of each property
-export type TypedObjectParameterDefinition =
-  & UntypedObjectParameterDefinition
-  & {
-    /** A list of required property names (must reference names defined on the `properties` property). Only for use with Object types. */
-    required?: string[];
-    /** Whether the parameter can accept objects with additional keys beyond those defined via `properties` */
-    additionalProperties?: boolean;
-    /** Object defining what properties are allowed on the parameter. */
-    properties: {
-      [key: string]: PrimitiveParameterDefinition;
-    };
-  };
+// export type TypedObjectParameterDefinition =
+//   & UntypedObjectParameterDefinition
+//   & {
+//     /** A list of required property names (must reference names defined on the `properties` property). Only for use with Object types. */
+//     required?: string[];
+//     /** Whether the parameter can accept objects with additional keys beyond those defined via `properties` */
+//     additionalProperties?: boolean;
+//     /** Object defining what properties are allowed on the parameter. */
+//     properties: {
+//       [key: string]: PrimitiveParameterDefinition;
+//     };
+// };
 
 type BooleanParameterDefinition = BaseParameterDefinition<boolean> & {
   type: typeof SchemaTypes.boolean;
@@ -71,29 +71,29 @@ type StringParameterDefinition = BaseParameterDefinition<string> & {
   choices?: EnumChoice<string>[];
 };
 
-type IntegerParameterDefinition = BaseParameterDefinition<number> & {
-  type: typeof SchemaTypes.integer;
-  /** Absolute minimum acceptable value for the integer */
-  minimum?: number;
-  /** Absolute maximum acceptable value for the integer */
-  maximum?: number;
-  /** Constrain the available integer options to just the list of integers denoted in the `enum` property. Usage of `enum` also instructs any UI that collects a value for this parameter to render a dropdown select input rather than a free-form text input. */
-  enum?: number[];
-  /** Defines labels that correspond to the `enum` values. */
-  choices?: EnumChoice<number>[];
-};
+// type IntegerParameterDefinition = BaseParameterDefinition<number> & {
+//   type: typeof SchemaTypes.integer;
+//   /** Absolute minimum acceptable value for the integer */
+//   minimum?: number;
+//   /** Absolute maximum acceptable value for the integer */
+//   maximum?: number;
+//   /** Constrain the available integer options to just the list of integers denoted in the `enum` property. Usage of `enum` also instructs any UI that collects a value for this parameter to render a dropdown select input rather than a free-form text input. */
+//   enum?: number[];
+//   /** Defines labels that correspond to the `enum` values. */
+//   choices?: EnumChoice<number>[];
+// };
 
-type NumberParameterDefinition = BaseParameterDefinition<number> & {
-  type: typeof SchemaTypes.number;
-  /** Absolute minimum acceptable value for the number */
-  minimum?: number;
-  /** Absolute maximum acceptable value for the number */
-  maximum?: number;
-  /** Constrain the available number options to just the list of numbers denoted in the `enum` property. Usage of `enum` also instructs any UI that collects a value for this parameter to render a dropdown select input rather than a free-form text input. */
-  enum?: number[];
-  /** Defines labels that correspond to the `enum` values. */
-  choices?: EnumChoice<number>[];
-};
+// type NumberParameterDefinition = BaseParameterDefinition<number> & {
+//   type: typeof SchemaTypes.number;
+//   /** Absolute minimum acceptable value for the number */
+//   minimum?: number;
+//   /** Absolute maximum acceptable value for the number */
+//   maximum?: number;
+//   /** Constrain the available number options to just the list of numbers denoted in the `enum` property. Usage of `enum` also instructs any UI that collects a value for this parameter to render a dropdown select input rather than a free-form text input. */
+//   enum?: number[];
+//   /** Defines labels that correspond to the `enum` values. */
+//   choices?: EnumChoice<number>[];
+// };
 
 type EnumChoice<T> = {
   /** The `enum` value this {@link EnumChoice} corresponds to. */

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -7,7 +7,7 @@ export type PrimitiveParameterDefinition =
   // | NumberParameterDefinition
   // | IntegerParameterDefinition
   | BaseParameterDefinition<AllValues>
-  | UntypedArrayParameterDefinition
+  // | UntypedArrayParameterDefinition
   | TypedArrayParameterDefinition;
 
 export type TypedParameterDefinition =

--- a/src/schema/schema_types.ts
+++ b/src/schema/schema_types.ts
@@ -1,9 +1,9 @@
 const SchemaTypes = {
   string: "string",
-  integer: "integer",
   boolean: "boolean",
-  number: "number",
-  object: "object",
+  // integer: "integer",
+  // number: "number",
+  // object: "object",
   array: "array",
 } as const;
 

--- a/src/schema/slack/schema_types.ts
+++ b/src/schema/slack/schema_types.ts
@@ -1,9 +1,9 @@
 const SlackTypes = {
   user_id: "slack#/types/user_id",
   channel_id: "slack#/types/channel_id",
-  usergroup_id: "slack#/types/usergroup_id",
-  timestamp: "slack#/types/timestamp",
-  blocks: "slack#/types/blocks",
+  // usergroup_id: "slack#/types/usergroup_id",
+  // timestamp: "slack#/types/timestamp",
+  // blocks: "slack#/types/blocks",
 } as const;
 
 export default SlackTypes;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -39,13 +39,16 @@ export class CustomType<Def extends CustomTypeDefinition>
       if (this.definition.items.type instanceof Object) {
         manifest.registerType(this.definition.items.type);
       }
-    } else if ("properties" in this.definition) {
-      // Loop through the properties and register any types
-      Object.values(this.definition.properties)?.forEach((property) => {
-        if ("type" in property && property.type instanceof Object) {
-          manifest.registerType(property.type);
-        }
-      });
+      // } else if ("properties" in this.definition) {
+      //   // Loop through the properties and register any types
+      //   Object.values(this.definition.properties)?.forEach((property) => {
+      //     if ("type" in property && property.type instanceof Object) {
+      //       manifest.registerType(property.type);
+      //     }
+      //   });
+    } else if (this.definition.type instanceof Object) {
+      // The referenced type is a Custom Type
+      manifest.registerType(this.definition.type);
     }
   }
 }


### PR DESCRIPTION
# Summary
Removing types that are not going to be supported at re-ignite.

Since the majority of these types will be re-added, I've commented them out for the time being.

## Justification
For re-ignite we are only supporting the following types, based on [this doc](https://corp.quip.com/XaUHABd6ZPUp/Reduce-function-input-type-support-to-match-Block-Kit-Decision):
- `string`
- `boolean`
- `user`
- `channel`
- `array` of
  - `string` as an `enum`
  - `user`
  - `channel