### PR TITLE
Use deps.ts and dev_deps.ts.

### DIFF
--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,0 +1,1 @@
+export { assertEquals } from "https://deno.land/std@0.134.0/testing/asserts.ts";

--- a/src/functions/functions_test.ts
+++ b/src/functions/functions_test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
 import { DefineFunction } from "./mod.ts";
 import Schema from "../schema/mod.ts";
+import { assertEquals } from "../dev_deps.ts";
 
 // TODO: Re-add tests to validate function execution when we've determined how to execute functions locally
 

--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -1,8 +1,8 @@
-import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
 import { SlackManifestType } from "./types.ts";
 
 import { Manifest, SlackManifest } from "./manifest.ts";
 import { DefineFunction, DefineType, Schema } from "./mod.ts";
+import { assertEquals } from "./dev_deps.ts";
 
 Deno.test("Manifest() property mappings", () => {
   const definition: SlackManifestType = {

--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -1,12 +1,8 @@
 import { SlackManifestType } from "./types.ts";
 
 import { Manifest, SlackManifest } from "./manifest.ts";
-<<<<<<< deps
-import { DefineFunction, DefineType, Schema } from "./mod.ts";
-import { assertEquals } from "./dev_deps.ts";
-=======
 import { DefineDatastore, DefineFunction, DefineType, Schema } from "./mod.ts";
->>>>>>> main
+import { assertEquals } from "./dev_deps.ts";
 
 Deno.test("Manifest() property mappings", () => {
   const definition: SlackManifestType = {

--- a/src/parameters/parameter-variable_test.ts
+++ b/src/parameters/parameter-variable_test.ts
@@ -1,7 +1,7 @@
-import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
 import SchemaTypes from "../schema/schema_types.ts";
 import { ParameterVariable } from "./mod.ts";
 import { DefineType } from "../types/mod.ts";
+import { assertEquals } from "../dev_deps.ts";
 
 Deno.test("ParameterVariable string", () => {
   const param = ParameterVariable("", "incident_name", {

--- a/src/parameters/with-untyped-object-proxy_test.ts
+++ b/src/parameters/with-untyped-object-proxy_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
 import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
+import { assertEquals } from "../dev_deps.ts";
 
 Deno.test("WithUntypedObjectProxy", () => {
   const ctx = WithUntypedObjectProxy({});


### PR DESCRIPTION
It is a good practice to centralise Deno dependencies within `deps.ts` and `dev_deps.ts` files.
See https://deno.land/manual/examples/manage_dependencies

---

Related to https://github.com/slackapi/deno-slack-api/pull/6 and https://github.com/slackapi/deno-slack-builder/pull/14