### PR TITLE
Remove runtime param from manifest

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -72,7 +72,6 @@ Once you have defined a function, don't forget to include it in your [`Manifest`
       description:
         "A demo showing how to use Slack functions",
       icon: "assets/icon.png",
-      runtime: "deno1.x",
       botScopes: ["commands", "chat:write", "chat:write.public"],
       functions: [ReverseString], // <-- don't forget this!
     });

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -16,7 +16,6 @@ Manifest({
   description:
     "A demo showing how to use Slack functions",
   icon: "assets/icon.png",
-  runtime: "deno1.x",
   botScopes: ["commands", "chat:write", "chat:write.public"],
   functions: [ReverseString],
   tables: [],
@@ -32,7 +31,6 @@ for the full list of attributes it supports, but the minimum required properties
 |`name`|string|Your Slack application name.|
 |`description`|string|A short sentence describing your application.|
 |`icon`|string|A relative path to an image asset to use for the application's icon.|
-|`runtime`|string|Which runtime this application can execute in. Only acceptable value at this point in time is `deno1.x`.|
 |`botScopes`|Array<string>|A list of [scopes][scopes], or permissions, the bot requires to function.|
 
 Furthermore, to set up how your application works, you would create

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -41,7 +41,6 @@ export class SlackManifest {
             def.name,
         },
       },
-      runtime: def.runtime,
       "outgoing_domains": def.outgoingDomains || [],
     } as ManifestSchema;
 

--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -14,7 +14,6 @@ Deno.test("Manifest() property mappings", () => {
       "The book is a roman à clef, rooted in autobiographical incidents. The story follows its protagonist, Raoul Duke, and his attorney, Dr. Gonzo, as they descend on Las Vegas to chase the American Dream...",
     displayName: "fear and loathing",
     icon: "icon.png",
-    runtime: "deno",
     botScopes: [],
   };
   let manifest = Manifest(definition);
@@ -82,7 +81,6 @@ Deno.test("Manifest() automatically registers types used by function input and o
     description: "Description",
     icon: "icon.png",
     longDescription: "LongDescription",
-    runtime: "deno",
     botScopes: [],
     functions: [Function],
   };
@@ -127,7 +125,6 @@ Deno.test("Manifest() automatically registers types referenced by other types", 
     description: "Description",
     icon: "icon.png",
     longDescription: "LongDescription",
-    runtime: "deno",
     botScopes: [],
     types: [ArrayType],
   };
@@ -169,7 +166,6 @@ Deno.test("SlackManifest() registration functions don't allow duplicates", () =>
     description: "Description",
     icon: "icon.png",
     longDescription: "LongDescription",
-    runtime: "deno",
     botScopes: [],
     functions: [Func],
     types: [CustomObjectType],

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,6 @@ export type SlackManifestType = {
   displayName?: string;
   icon: string;
   longDescription?: string;
-  runtime: string;
   botScopes: Array<string>;
   functions?: ManifestFunction[];
   outgoingDomains?: Array<string>;
@@ -98,7 +97,6 @@ export type ManifestSchema = {
       "display_name": string;
     };
   };
-  runtime?: string;
   functions?: {
     [key: string]: ManifestFunctionSchema;
   };


### PR DESCRIPTION
# Summary
Removing `runtime` from the manifest as it's no longer used by the builder as of https://github.com/slackapi/deno-slack-builder/pull/15