### PR TITLE
Add generic typing for functions

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -57,8 +57,8 @@ The single argument to your function is an object composed of several properties
 
 - `env`: represents environment variables available to your function's execution context.
 - `inputs`: an object containing the input parameters you defined as part of your Function Definition. In the example above, the `name` input parameter is available on the `inputs` property of our function handler context.
-- `token`: Your application's access token
-- `event`: The full event object
+- `token`: your application's access token.
+- `event`: an object containing the full incoming event details.
 
 ### Adding Functions to the Manifest
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -57,6 +57,8 @@ The single argument to your function is an object composed of several properties
 
 - `env`: represents environment variables available to your function's execution context.
 - `inputs`: an object containing the input parameters you defined as part of your Function Definition. In the example above, the `name` input parameter is available on the `inputs` property of our function handler context.
+- `token`: Your application's access token
+- `event`: The full event object
 
 ### Adding Functions to the Manifest
 

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -43,6 +43,7 @@ export type FunctionContext<InputParameters> = {
   // TODO: Support types generated from manifest
   inputs: InputParameters;
   token: string;
+  event: FunctionInvocationBody["event"];
 };
 export interface ISlackFunction<
   InputParameters extends ParameterSetDefinition,

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -1,15 +1,8 @@
 import { Env, ManifestFunctionSchema } from "../types.ts";
 import {
-  ParameterDefinition,
   ParameterSetDefinition,
   RequiredParameters,
 } from "../parameters/mod.ts";
-import {
-  TypedArrayParameterDefinition,
-  // TypedObjectParameterDefinition,
-} from "../parameters/types.ts";
-import SchemaTypes from "../schema/schema_types.ts";
-import SlackSchemaTypes from "../schema/slack/schema_types.ts";
 import { SlackManifest } from "../manifest.ts";
 
 export type FunctionInvocationBody = {
@@ -31,104 +24,26 @@ export type FunctionInvocationBody = {
   };
 };
 
-export type FunctionHandler<
-  InputParameters extends ParameterSetDefinition,
-  OutputParameters extends ParameterSetDefinition,
-  RequiredInput extends RequiredParameters<InputParameters>,
-  RequiredOutputs extends RequiredParameters<OutputParameters>,
-> = {
-  // TODO: Type the return args of promise more
-  (context: FunctionContext<InputParameters, RequiredInput>): Promise<
-    FunctionHandlerReturnArgs<OutputParameters, RequiredOutputs>
-  >;
+export type FunctionHandler<InputParameters, OutputParameters> = {
+  (
+    context: FunctionContext<InputParameters>,
+  ): Promise<FunctionHandlerReturnArgs<OutputParameters>>;
 };
 
-// TODO: Type the outputs similar to the inputs
-export type FunctionHandlerReturnArgs<
-  OutputParameters extends ParameterSetDefinition,
-  RequiredOutputs extends RequiredParameters<OutputParameters>,
-> = {
+export type FunctionHandlerReturnArgs<OutputParameters> = {
   completed?: boolean;
-  outputs?: FunctionInputs<OutputParameters, RequiredOutputs>;
+  outputs: OutputParameters;
   error?: string;
 };
 
-export type FunctionContext<
-  InputParameters extends ParameterSetDefinition,
-  RequiredInputs extends RequiredParameters<InputParameters>,
-> = {
-  // TODO: Type the values to our supported types?
+export type FunctionContext<InputParameters> = {
   /** A map of string keys to string values containing any environment variables available and provided to your function handler's execution context. */
   env: Env;
   /** The inputs to the function as defined by your function definition. */
   // TODO: Support types generated from manifest
-  inputs: FunctionInputs<
-    InputParameters,
-    RequiredInputs
-  >;
-  executionId: string;
+  inputs: InputParameters;
+  token: string;
 };
-
-/* START TODO: Remove Runtime Generic Typing in favor of Generated Types */
-
-type FunctionInputRuntimeType<Param extends ParameterDefinition> =
-  Param["type"] extends typeof SchemaTypes.string ? string
-    : // : Param["type"] extends
-    //   | typeof SchemaTypes.integer
-    //   | typeof SchemaTypes.number ? number
-    Param["type"] extends typeof SchemaTypes.boolean ? boolean
-    : Param["type"] extends typeof SchemaTypes.array
-      ? Param extends TypedArrayParameterDefinition
-        ? TypedArrayFunctionInputRuntimeType<Param>
-      : UnknownRuntimeType[]
-    : // : Param["type"] extends typeof SchemaTypes.object
-    //   ? Param extends TypedObjectParameterDefinition
-    //     ? TypedObjectFunctionInputRuntimeType<Param>
-    //   : UnknownRuntimeType
-    // TODO: Look at moving these slack runtime type declarations into the slack type definitions once we have DefineType and can use it there
-    Param["type"] extends
-      | typeof SlackSchemaTypes.user_id
-      | typeof SlackSchemaTypes.channel_id ? // | typeof SlackSchemaTypes.usergroup_id
-    string
-    : // : Param["type"] extends typeof SlackSchemaTypes.timestamp ? number
-    UnknownRuntimeType;
-
-// deno-lint-ignore no-explicit-any
-type UnknownRuntimeType = any;
-
-// type TypedObjectFunctionInputRuntimeType<
-//   Param extends TypedObjectParameterDefinition,
-// > =
-//   & {
-//     [k in keyof Param["properties"]]: FunctionInputRuntimeType<
-//       Param["properties"][k]
-//     >;
-//   }
-//   & {
-//     [key: string]: UnknownRuntimeType;
-//   };
-
-type TypedArrayFunctionInputRuntimeType<
-  Param extends TypedArrayParameterDefinition,
-> = FunctionInputRuntimeType<Param["items"]>[];
-
-type FunctionInputs<
-  InputParameters extends ParameterSetDefinition,
-  RequiredInputs extends RequiredParameters<InputParameters>,
-> =
-  & {
-    [k in RequiredInputs[number]]: FunctionInputRuntimeType<
-      InputParameters[k]
-    >;
-  }
-  & {
-    [k in keyof InputParameters]?: FunctionInputRuntimeType<
-      InputParameters[k]
-    >;
-  };
-
-/* END TODO: Remove Runtime Generic Typing in favor of Generated Types */
-
 export interface ISlackFunction<
   InputParameters extends ParameterSetDefinition,
   OutputParameters extends ParameterSetDefinition,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,15 @@
-import { ISlackFunction } from "./functions/types.ts";
-import { ISlackDatastore } from "./datastore/types.ts";
-import {
+import type { ISlackFunction } from "./functions/types.ts";
+import type { ISlackDatastore } from "./datastore/types.ts";
+import type {
   ParameterDefinition,
   ParameterSetDefinition,
 } from "./parameters/mod.ts";
-import { ICustomType } from "./types/types.ts";
+import type { ICustomType } from "./types/types.ts";
 
 // SlackManifestType is the top level type that imports all resources for the app
 // An app manifest is generated based on what this has defined in it
 
+export type { FunctionHandler } from "./functions/types.ts";
 export type SlackManifestType = {
   name: string;
   backgroundColor?: string;


### PR DESCRIPTION
# Summary
Adjusting the `FunctionHandler` type to provide some typing for functions at reignite.

## Details

#### Reignite Target
At reignite, this will be used in our template function definition file like
```ts
import type { FunctionHandler } from "deno-slack-sdk/types.ts";

// deno-lint-ignore no-explicit-any
const reverse: FunctionHandler<any, any> = async (
  { inputs, env },
) => {
  const reverseString = inputs.stringToReverse.split("").reverse().join("");
  return await {
    outputs: { reverseString },
  };
};

export default reverse;
```

Out of the box, the dev will get typing on all parts of the function other than their inputs and outputs. They will also be able to type the function themselves if they want to maintain them.

#### Type Generation Target

After type generation is in place, this will look like

```ts
// generated-types/reverse.ts file
import type { FunctionHandler } from "deno-slack-sdk/types.ts";

type ReverseInputs = { stringToReverse: string };
type ReverseOutputs = { reverseString: string };

export type ReverseFunctionHandler = FunctionHandler<
  ReverseInputs,
  ReverseOutputs
>;
```

```ts
// generated-types/mod.ts file
export type { ReverseFunctionHandler } from "./reverse.ts";
```

```ts
// reverse.ts file
import { ReverseFunctionHandler } from "./generated-types/mod.ts";

const reverse: ReverseFunctionHandler = async ({ inputs, env }) => {
  const reverseString = inputs.stringToReverse.split("").reverse().join("");
  return await {
    outputs: { reverseString },
  };
};

export default reverse;
```