### PR TITLE
Add type registration to datastores and auto-append scopes

### DIFF
--- a/src/datastore/mod.ts
+++ b/src/datastore/mod.ts
@@ -1,3 +1,4 @@
+import { SlackManifest } from "../manifest.ts";
 import { ManifestDatastoreSchema } from "../types.ts";
 import {
   ISlackDatastore,
@@ -17,11 +18,19 @@ export const DefineDatastore = <Attributes extends SlackDatastoreAttributes>(
 };
 
 export class SlackDatastore<Attributes extends SlackDatastoreAttributes>
-  implements ISlackDatastore<Attributes> {
+  implements ISlackDatastore {
   public name: string;
 
   constructor(private definition: SlackDatastoreDefinition<Attributes>) {
     this.name = definition.name;
+  }
+
+  registerAttributeTypes(manifest: SlackManifest) {
+    Object.values(this.definition.attributes ?? {})?.forEach((attribute) => {
+      if (attribute.type instanceof Object) {
+        manifest.registerType(attribute.type);
+      }
+    });
   }
 
   export(): ManifestDatastoreSchema {

--- a/src/datastore/types.ts
+++ b/src/datastore/types.ts
@@ -1,5 +1,6 @@
 import { ICustomType } from "../types/types.ts";
 import { ManifestDatastoreSchema } from "../types.ts";
+import { SlackManifest } from "../manifest.ts";
 
 export type SlackDatastoreAttribute = {
   // supports custom types, primitive types, inline objects and lists
@@ -16,9 +17,10 @@ export type SlackDatastoreDefinition<
   attributes: Attributes;
 };
 
-export interface ISlackDatastore<Attributes extends SlackDatastoreAttributes> {
+export interface ISlackDatastore {
   name: string;
   export: () => ManifestDatastoreSchema;
+  registerAttributeTypes: (manifest: SlackManifest) => void;
 }
 
 export type SlackDatastoreItem<Attributes extends SlackDatastoreAttributes> = {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -75,6 +75,11 @@ export class SlackManifest {
       func.registerParameterTypes(this);
     });
 
+    // Loop through datastores to automatically register any referenced types
+    this.definition.datastores?.forEach((datastore) => {
+      datastore.registerAttributeTypes(this);
+    });
+
     // Loop through types to automatically register any referenced sub-types
     const registeredTypes = this.definition.types || [];
     for (let i = 0; i < registeredTypes.length; i++) {
@@ -111,7 +116,16 @@ export class SlackManifest {
 
   private ensureBotScopes(): string[] {
     const includedScopes = this.definition.botScopes || [];
-    // TODO: Add datastore scopes
+
+    // Add datastore scopes if necessary
+    if (Object.keys(this.definition.datastores ?? {}).length > 0) {
+      const datastoreScopes = ["datastore:read", "datastore:write"];
+      datastoreScopes.forEach((scope) => {
+        if (!includedScopes.includes(scope)) {
+          includedScopes.push(scope);
+        }
+      });
+    }
 
     return includedScopes;
   }

--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
 import { SlackManifestType } from "./types.ts";
 
 import { Manifest, SlackManifest } from "./manifest.ts";
-import { DefineFunction, DefineType, Schema } from "./mod.ts";
+import { DefineDatastore, DefineFunction, DefineType, Schema } from "./mod.ts";
 
 Deno.test("Manifest() property mappings", () => {
   const definition: SlackManifestType = {
@@ -99,6 +99,34 @@ Deno.test("Manifest() automatically registers types used by function input and o
     [stringTypeId]: CustomStringType.definition,
     [outputTypeId]: CustomOutputType.definition,
   });
+});
+
+Deno.test("Manifest() automatically registers types referenced by datastores", () => {
+  const stringTypeId = "test_string_type";
+  const StringType = DefineType({
+    callback_id: stringTypeId,
+    type: Schema.types.string,
+  });
+
+  const Store = DefineDatastore({
+    name: "Test store",
+    attributes: {
+      aString: { type: StringType },
+    },
+    primary_key: "aString",
+  });
+
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    runtime: "deno",
+    botScopes: [],
+    datastores: [Store],
+  };
+  const manifest = Manifest(definition);
+  assertEquals(definition.types, [StringType]);
+  assertEquals(manifest.types, { [stringTypeId]: StringType.definition });
 });
 
 Deno.test("Manifest() automatically registers types referenced by other types", () => {
@@ -231,4 +259,66 @@ Deno.test("SlackManifest() registration functions don't allow duplicates", () =>
     [arrayTypeId]: CustomArrayType.definition,
     [stringTypeId]: CustomStringType.definition,
   });
+});
+
+Deno.test("SlackManifest.export() ensures datastore scopes if they are not present", () => {
+  const Store = DefineDatastore({
+    name: "test store",
+    attributes: {
+      attr: {
+        type: Schema.types.string,
+      },
+    },
+    primary_key: "attr",
+  });
+
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    longDescription: "LongDescription",
+    runtime: "deno",
+    botScopes: [],
+    datastores: [Store],
+  };
+
+  const Manifest = new SlackManifest(definition);
+  const exportedManifest = Manifest.export();
+  const botScopes = exportedManifest.oauth_config.scopes.bot;
+  assertEquals(botScopes.includes("datastore:read"), true);
+  assertEquals(botScopes.includes("datastore:write"), true);
+});
+
+Deno.test("SlackManifest.export() will not duplicate datastore scopes if they're already present", () => {
+  const Store = DefineDatastore({
+    name: "test store",
+    attributes: {
+      attr: {
+        type: Schema.types.string,
+      },
+    },
+    primary_key: "attr",
+  });
+
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    longDescription: "LongDescription",
+    runtime: "deno",
+    botScopes: ["datastore:read", "datastore:write"],
+    datastores: [Store],
+  };
+
+  const Manifest = new SlackManifest(definition);
+  const exportedManifest = Manifest.export();
+  const botScopes = exportedManifest.oauth_config.scopes.bot;
+  assertEquals(
+    botScopes.filter((scope) => scope === "datastore:read").length,
+    1,
+  );
+  assertEquals(
+    botScopes.filter((scope) => scope === "datastore:write").length,
+    1,
+  );
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,15 +24,12 @@ export type SlackManifestType = {
   datastores?: ManifestDatastore[];
 };
 
-// Both of these are typed liberally at this level but more specifically down further
+export type ManifestDatastore = ISlackDatastore;
+
+// This is typed liberally at this level but more specifically down further
 // This is to work around an issue TS has with resolving the generics across the hierarchy
 // deno-lint-ignore no-explicit-any
 export type ManifestFunction = ISlackFunction<any, any, any, any>;
-
-// Both of these are typed liberally at this level but more specifically down further
-// This is to work around an issue TS has with resolving the generics across the hierarchy
-// deno-lint-ignore no-explicit-any
-export type ManifestDatastore = ISlackDatastore<any>;
 
 // ----------------------------------------------------------------------------
 // Invocation


### PR DESCRIPTION
# Summary

Adding some logic to
- automatically register types used by datastores
- automatically append datastore scopes to bot scopes