### PR TITLE
Make function handler types optional

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -38,12 +38,12 @@ export type FunctionHandlerReturnArgs<OutputParameters> = {
 
 export type FunctionContext<InputParameters> = {
   /** A map of string keys to string values containing any environment variables available and provided to your function handler's execution context. */
-  env: Env;
+  env?: Env;
   /** The inputs to the function as defined by your function definition. */
   // TODO: Support types generated from manifest
   inputs: InputParameters;
-  token: string;
-  event: FunctionInvocationBody["event"];
+  token?: string;
+  event?: FunctionInvocationBody["event"];
 };
 export interface ISlackFunction<
   InputParameters extends ParameterSetDefinition,


### PR DESCRIPTION
# Summary

These args are always passed in by the runtime, but having the requirement for `Env`, `token`, and `event` args means that they must be provided via tests. I think we can loosen this up as optional params rather than require them in to be defined in every test file.