### PR TITLE
adding a SlackFunctionTester to help with writing function tests

### DIFF
--- a/src/functions/function_tester.ts
+++ b/src/functions/function_tester.ts
@@ -1,12 +1,9 @@
-import { Env } from "../types.ts";
-import { FunctionContext, FunctionInvocationBody } from "./types.ts";
-
-type SlackFunctionTesterArgs<InputParameters> = {
-  inputs: InputParameters;
-  env?: Env;
-  token?: string;
-  event?: FunctionInvocationBody["event"];
-};
+import type { FunctionContext } from "./types.ts";
+type SlackFunctionTesterArgs<InputParameters> =
+  & Partial<FunctionContext<InputParameters>>
+  & {
+    inputs: InputParameters;
+  };
 
 export const SlackFunctionTester = (callbackId: string) => {
   const now = new Date();

--- a/src/functions/function_tester.ts
+++ b/src/functions/function_tester.ts
@@ -1,0 +1,39 @@
+import { Env } from "../types.ts";
+import { FunctionContext, FunctionInvocationBody } from "./types.ts";
+
+type SlackFunctionTesterArgs<InputParameters> = {
+  inputs: InputParameters;
+  env?: Env;
+  token?: string;
+  event?: FunctionInvocationBody["event"];
+};
+
+export const SlackFunctionTester = (callbackId: string) => {
+  const now = new Date();
+  const testFnID = `fn${now.getTime()}`;
+
+  const createContext = <InputParameters>(
+    args: SlackFunctionTesterArgs<InputParameters>,
+  ): FunctionContext<InputParameters> => {
+    const ts = new Date();
+
+    return {
+      inputs: args.inputs,
+      env: args.env || {},
+      token: args.token || "slack-function-test-token",
+      event: args.event || {
+        type: "function_executed",
+        event_ts: `${ts.getTime()}`,
+        function_execution_id: `fx${ts.getTime()}`,
+        inputs: args.inputs as Record<string, unknown>,
+        function: {
+          id: testFnID,
+          callback_id: callbackId,
+          title: "Function Test Title",
+        },
+      },
+    };
+  };
+
+  return { createContext };
+};

--- a/src/functions/function_tester_test.ts
+++ b/src/functions/function_tester_test.ts
@@ -1,0 +1,20 @@
+import { assertEquals } from "../dev_deps.ts";
+import { SlackFunctionTester } from "./function_tester.ts";
+
+Deno.test("SlackFunctionTester.createContext", () => {
+  const callbackId = "my_callback_id";
+  const { createContext } = SlackFunctionTester(callbackId);
+
+  const inputs = {
+    myValue: "some value",
+  };
+  const ctx = createContext({
+    inputs,
+  });
+
+  assertEquals(ctx.inputs, inputs);
+  assertEquals(ctx.env, {});
+  assertEquals(typeof ctx.token, "string");
+  assertEquals(ctx.event.type, "function_executed");
+  assertEquals(ctx.event.function.callback_id, callbackId);
+});

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,7 +1,6 @@
-// TODO: need to work on a more explicit public api for this sdk module
-// Current pass is mostly just exporting everything we want to iterate on
 export { Manifest } from "./manifest.ts";
 export { DefineFunction } from "./functions/mod.ts";
 export { DefineType } from "./types/mod.ts";
 export { default as Schema } from "./schema/mod.ts";
 export { DefineDatastore } from "./datastore/mod.ts";
+export { SlackFunctionTester } from "./functions/function_tester.ts";


### PR DESCRIPTION
## Summary
This creates a new top level export of `SlackFunctionTester` that can be used to ease writing tests for Slack Functions. Consuming it would like like the following when writing a test for  a function in your project:

```ts
// Can call this anywhere in your test file
const { createContext } = SlackFunctionTester("reverse_string");
```

And then in your tests where you need to pass arguments into your function...
```ts
const { outputs } = await ReverseString(createContext({ inputs }));


A full test would like like the following:
```ts
import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
import ReverseString from "./reverse.ts";
import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";

const { createContext } = SlackFunctionTester("reverse_string");

Deno.test("Reverse string function test", async () => {
  const inputs = { stringToReverse: "foo" };
  const { outputs } = await ReverseString(createContext({ inputs }));
  assertEquals(outputs?.reverseString, "oof");
});
```

I think we could expand on what helper functions `SlackFunctionTester()` returns if we need over time, but initially this will help developers have more realistic arguments into their functions w/ low effort.