### PR TITLE
[HERMES-2473] Function return args no longer require an output if there is an error

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -30,11 +30,23 @@ export type FunctionHandler<InputParameters, OutputParameters> = {
   ): Promise<FunctionHandlerReturnArgs<OutputParameters>>;
 };
 
-export type FunctionHandlerReturnArgs<OutputParameters> = {
-  completed?: boolean;
+type ReturnArgs<OutputParameters> = {
+  completed: boolean;
   outputs: OutputParameters;
-  error?: string;
+  error: string;
 };
+
+type SuccessfulFunctionReturnArgs<OutputParameters> =
+  & Partial<ReturnArgs<OutputParameters>>
+  & Required<Pick<ReturnArgs<OutputParameters>, "outputs">>;
+
+type ErroredFunctionReturnArgs<OutputParameters> =
+  & Partial<ReturnArgs<OutputParameters>>
+  & Required<Pick<ReturnArgs<OutputParameters>, "error">>;
+
+export type FunctionHandlerReturnArgs<OutputParameters> =
+  | SuccessfulFunctionReturnArgs<OutputParameters>
+  | ErroredFunctionReturnArgs<OutputParameters>;
 
 export type FunctionContext<InputParameters> = {
   /** A map of string keys to string values containing any environment variables available and provided to your function handler's execution context. */

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -30,19 +30,19 @@ export type FunctionHandler<InputParameters, OutputParameters> = {
   ): Promise<FunctionHandlerReturnArgs<OutputParameters>>;
 };
 
-type ReturnArgs<OutputParameters> = {
+type FunctionReturnArgs<OutputParameters> = {
   completed: boolean;
   outputs: OutputParameters;
   error: string;
 };
 
 type SuccessfulFunctionReturnArgs<OutputParameters> =
-  & Partial<ReturnArgs<OutputParameters>>
-  & Required<Pick<ReturnArgs<OutputParameters>, "outputs">>;
+  & Partial<FunctionReturnArgs<OutputParameters>>
+  & Required<Pick<FunctionReturnArgs<OutputParameters>, "outputs">>;
 
 type ErroredFunctionReturnArgs<OutputParameters> =
-  & Partial<ReturnArgs<OutputParameters>>
-  & Required<Pick<ReturnArgs<OutputParameters>, "error">>;
+  & Partial<FunctionReturnArgs<OutputParameters>>
+  & Required<Pick<FunctionReturnArgs<OutputParameters>, "error">>;
 
 export type FunctionHandlerReturnArgs<OutputParameters> =
   | SuccessfulFunctionReturnArgs<OutputParameters>

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -30,19 +30,15 @@ export type FunctionHandler<InputParameters, OutputParameters> = {
   ): Promise<FunctionHandlerReturnArgs<OutputParameters>>;
 };
 
-type FunctionReturnArgs<OutputParameters> = {
-  completed: boolean;
+type SuccessfulFunctionReturnArgs<OutputParameters> = {
+  completed?: boolean;
   outputs: OutputParameters;
-  error: string;
+  error?: string;
 };
 
-type SuccessfulFunctionReturnArgs<OutputParameters> =
-  & Partial<FunctionReturnArgs<OutputParameters>>
-  & Required<Pick<FunctionReturnArgs<OutputParameters>, "outputs">>;
-
 type ErroredFunctionReturnArgs<OutputParameters> =
-  & Partial<FunctionReturnArgs<OutputParameters>>
-  & Required<Pick<FunctionReturnArgs<OutputParameters>, "error">>;
+  & Partial<SuccessfulFunctionReturnArgs<OutputParameters>>
+  & Required<Pick<SuccessfulFunctionReturnArgs<OutputParameters>, "error">>;
 
 export type FunctionHandlerReturnArgs<OutputParameters> =
   | SuccessfulFunctionReturnArgs<OutputParameters>


### PR DESCRIPTION
JIRA TIcket: [HERMES-2473](https://jira.tinyspeck.com/browse/HERMES-2473)

### Summary

If we catch an error in the function execution, we should be able to return the error without needing to set any outputs.


### Description
Right now if we return from a caught error we need to provide outputs
```ts
  try {
    throw new Error();
  } catch (e) {
    return await {
      error: e,
      outputs: {}
    };
  }
  ```
  
  but this isn't required by our BE so we shouldn't require `outputs` in the response if `error` is provided
  ```ts
```ts
  try {
    throw new Error();
  } catch (e) {
    return await {
      error: e,
    };
  }
  ```