### PR TITLE
Move the required field under the properties

### DIFF
--- a/src/functions/functions_test.ts
+++ b/src/functions/functions_test.ts
@@ -25,7 +25,6 @@ Deno.test("Function with required params", () => {
     title: "All Types Function",
     source_file: "functions/example.ts",
     input_parameters: {
-      required: ["myString" /* , "myNumber" */],
       properties: {
         myString: {
           type: Schema.types.string,
@@ -45,14 +44,15 @@ Deno.test("Function with required params", () => {
         //   description: "number",
         // },
       },
+      required: ["myString" /* , "myNumber" */],
     },
     output_parameters: {
-      required: ["out"],
       properties: {
         out: {
           type: Schema.types.string,
         },
       },
+      required: ["out"],
     },
   });
 
@@ -81,10 +81,10 @@ Deno.test("Function without input and output parameters", () => {
 
 Deno.test("Function with input parameters but no output parameters", () => {
   const inputParameters = {
-    required: [],
     properties: {
       aString: { type: Schema.types.string },
     },
+    required: [],
   };
   const NoOutputParamFunction = DefineFunction({
     callback_id: "input_params_only",
@@ -107,10 +107,10 @@ Deno.test("Function with input parameters but no output parameters", () => {
 
 Deno.test("Function with output parameters but no input parameters", () => {
   const outputParameters = {
-    required: [],
     properties: {
       aString: { type: Schema.types.string },
     },
+    required: [],
   };
   const NoInputParamFunction = DefineFunction({
     callback_id: "output_params_only",

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -76,12 +76,12 @@ export type FunctionDefinitionArgs<
   description?: string;
   /** An optional map of input parameter names containing information about their type, title, description, required and (additional) properties. */
   "input_parameters"?: {
-    required: RequiredInput;
     properties: InputParameters;
+    required: RequiredInput;
   };
   /** An optional map of output parameter names containing information about their type, title, description, required and (additional) properties. */
   "output_parameters"?: {
-    required: RequiredOutputs;
     properties: OutputParameters;
+    required: RequiredOutputs;
   };
 };

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -24,8 +24,8 @@ export type RequiredParameters<
 export type ParameterPropertiesDefinition<
   Parameters extends ParameterSetDefinition,
 > = {
-  required: RequiredParameters<Parameters>;
   properties: Parameters;
+  required: RequiredParameters<Parameters>;
 };
 
 export type ParameterVariableType<Def extends ParameterDefinition> = Def extends


### PR DESCRIPTION
### Summary
Moving the required field beneath the properties

### Details
There was confusion about a TS error around a required field that wasn't actually a parameter yet. We haven't figured out the right way to give specific error messaging for this kind of situation with our types, but it makes more sense to define the properties that are available before we say which are required.

Convo: https://slack-pde.slack.com/archives/C03BS52QLPJ/p1649958372816539
Relevant PR: https://github.com/slackapi/deno-reverse-string/pull/24