### PR TITLE
Support async and sync function handlers

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -24,11 +24,21 @@ export type FunctionInvocationBody = {
   };
 };
 
-export type FunctionHandler<InputParameters, OutputParameters> = {
+type AsyncFunctionHandler<InputParameters, OutputParameters> = {
   (
     context: FunctionContext<InputParameters>,
   ): Promise<FunctionHandlerReturnArgs<OutputParameters>>;
 };
+
+type SyncFunctionHandler<InputParameters, OutputParameters> = {
+  (
+    context: FunctionContext<InputParameters>,
+  ): FunctionHandlerReturnArgs<OutputParameters>;
+};
+
+export type FunctionHandler<InputParameters, OutputParameters> =
+  | AsyncFunctionHandler<InputParameters, OutputParameters>
+  | SyncFunctionHandler<InputParameters, OutputParameters>;
 
 type SuccessfulFunctionReturnArgs<OutputParameters> = {
   completed?: boolean;


### PR DESCRIPTION
## Summary

This goes along with the following PR for the runtime: https://github.com/slackapi/deno-slack-runtime/pull/12

After that runtime is released, we can release this type change to allow sync or async function handlers. This will allow someone to write a function handler w/o the `async` keyword if they don't need it. So instead of:

```ts
const reverse: FunctionHandler<any, any> = async ({ inputs, env }) => {
  const reverseString = inputs.stringToReverse.split("").reverse().join("");

  return await {
    outputs: { reverseString },
  };
};
```

It could just be:

```ts
const reverse: FunctionHandler<any, any> = ({ inputs, env }) => {
  const reverseString = inputs.stringToReverse.split("").reverse().join("");

  return {
    outputs: { reverseString },
  };
};
```