### PR TITLE
Updating datastore types with generics and making definition public

### DIFF
--- a/src/datastore/mod.ts
+++ b/src/datastore/mod.ts
@@ -8,20 +8,29 @@ import {
 
 /**
  * Define a datastore and primary key and attributes for use in a Slack application.
- * @param {SlackDatastoreDefinition<SlackDatastoreAttributes>} definition Defines information about your datastore.
+ * @param {SlackDatastoreDefinition<string, SlackDatastoreAttributes, string>} definition Defines information about your datastore.
  * @returns {SlackDatastore}
  */
-export const DefineDatastore = <Attributes extends SlackDatastoreAttributes>(
-  definition: SlackDatastoreDefinition<Attributes>,
+export const DefineDatastore = <
+  Name extends string,
+  Attributes extends SlackDatastoreAttributes,
+  PrimaryKey extends keyof Attributes,
+>(
+  definition: SlackDatastoreDefinition<Name, Attributes, PrimaryKey>,
 ) => {
   return new SlackDatastore(definition);
 };
 
-export class SlackDatastore<Attributes extends SlackDatastoreAttributes>
-  implements ISlackDatastore {
-  public name: string;
+export class SlackDatastore<
+  Name extends string,
+  Attributes extends SlackDatastoreAttributes,
+  PrimaryKey extends keyof Attributes,
+> implements ISlackDatastore {
+  public name: Name;
 
-  constructor(private definition: SlackDatastoreDefinition<Attributes>) {
+  constructor(
+    public definition: SlackDatastoreDefinition<Name, Attributes, PrimaryKey>,
+  ) {
     this.name = definition.name;
   }
 

--- a/src/datastore/types.ts
+++ b/src/datastore/types.ts
@@ -10,10 +10,12 @@ export type SlackDatastoreAttribute = {
 export type SlackDatastoreAttributes = Record<string, SlackDatastoreAttribute>;
 
 export type SlackDatastoreDefinition<
+  Name extends string,
   Attributes extends SlackDatastoreAttributes,
+  PrimaryKey extends keyof Attributes,
 > = {
-  name: string;
-  "primary_key": keyof Attributes;
+  name: Name;
+  "primary_key": PrimaryKey;
   attributes: Attributes;
 };
 


### PR DESCRIPTION
## Summary

Making the `definition` property of a Datastore instance public (so we can reference it [for typed apis](https://github.com/slackapi/deno-slack-api/pull/9)). Also added generics for `name` and `primary_key` to support stricter typing on apis using the definitions as generics.

## Testing
This should change anything with how a datastore is created/referenced in the SDK alone, but will allow testing a new PR to the api client w/ typed datastore methods.

https://github.com/slackapi/deno-slack-api/pull/9
