### PR TITLE
Making typed function handlers easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.coverage

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "test": "deno test src && deno fmt --check src && deno lint src",
+    "coverage": "deno test --allow-read --coverage=.coverage && deno coverage --exclude=fixtures|test .coverage"
+  }
+}

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,4 +1,5 @@
 export {
   assertEquals,
+  assertExists,
   assertStrictEquals,
 } from "https://deno.land/std@0.134.0/testing/asserts.ts";

--- a/src/functions/base_function_handler_type_test.ts
+++ b/src/functions/base_function_handler_type_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "../dev_deps.ts";
+import { SlackFunctionTester } from "./function_tester.ts";
 import { BaseSlackFunctionHandler } from "./types.ts";
 
 // These tests are to ensure our Function Handler types are supporting the use cases we want to
@@ -20,7 +21,10 @@ Deno.test("BaseSlackFunctionHandler types", () => {
       },
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const inputs = { in: "test" };
+  const result = handler(createContext({ inputs }));
+  assertEquals(result.outputs?.out, inputs.in);
 });
 
 Deno.test("BaseSlackFunctionHandler with empty inputs and outputs", () => {
@@ -31,7 +35,9 @@ Deno.test("BaseSlackFunctionHandler with empty inputs and outputs", () => {
       outputs: {},
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const result = handler(createContext({ inputs: {} }));
+  assertEquals(result.outputs, {});
 });
 
 Deno.test("BaseSlackFunctionHandler with undefined inputs and outputs", () => {
@@ -42,7 +48,9 @@ Deno.test("BaseSlackFunctionHandler with undefined inputs and outputs", () => {
       outputs: {},
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const result = handler(createContext({ inputs: undefined }));
+  assertEquals(result.outputs, {});
 });
 
 Deno.test("BaseSlackFunctionHandler with inputs and empty outputs", () => {
@@ -57,7 +65,10 @@ Deno.test("BaseSlackFunctionHandler with inputs and empty outputs", () => {
       outputs: {},
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const inputs = { in: "test" };
+  const result = handler(createContext({ inputs }));
+  assertEquals(result.outputs, {});
 });
 
 Deno.test("BaseSlackFunctionHandler with empty inputs and outputs", () => {
@@ -72,7 +83,9 @@ Deno.test("BaseSlackFunctionHandler with empty inputs and outputs", () => {
       },
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const result = handler(createContext({ inputs: {} }));
+  assertEquals(result.outputs?.out, "test");
 });
 
 Deno.test("BaseSlackFunctionHandler with any inputs and any outputs", () => {
@@ -84,7 +97,10 @@ Deno.test("BaseSlackFunctionHandler with any inputs and any outputs", () => {
       },
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const inputs = { in: "test" };
+  const result = handler(createContext({ inputs }));
+  assertEquals(result.outputs?.out, inputs.in);
 });
 
 Deno.test("BaseSlackFunctionHandler with set inputs and any outputs", () => {
@@ -99,5 +115,8 @@ Deno.test("BaseSlackFunctionHandler with set inputs and any outputs", () => {
       },
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const inputs = { in: "test" };
+  const result = handler(createContext({ inputs }));
+  assertEquals(result.outputs?.out, inputs.in);
 });

--- a/src/functions/base_function_handler_type_test.ts
+++ b/src/functions/base_function_handler_type_test.ts
@@ -1,0 +1,103 @@
+import { assertEquals } from "../dev_deps.ts";
+import { BaseSlackFunctionHandler } from "./types.ts";
+
+// These tests are to ensure our Function Handler types are supporting the use cases we want to
+// Any "failures" here will most likely be reflected in Type errors
+
+Deno.test("BaseSlackFunctionHandler types", () => {
+  type Inputs = {
+    in: string;
+  };
+  type Outputs = {
+    out: string;
+  };
+  const handler: BaseSlackFunctionHandler<Inputs, Outputs> = (
+    { inputs },
+  ) => {
+    return {
+      outputs: {
+        out: inputs.in,
+      },
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("BaseSlackFunctionHandler with empty inputs and outputs", () => {
+  type Inputs = Record<never, never>;
+  type Outputs = Record<never, never>;
+  const handler: BaseSlackFunctionHandler<Inputs, Outputs> = () => {
+    return {
+      outputs: {},
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("BaseSlackFunctionHandler with undefined inputs and outputs", () => {
+  type Inputs = undefined;
+  type Outputs = undefined;
+  const handler: BaseSlackFunctionHandler<Inputs, Outputs> = () => {
+    return {
+      outputs: {},
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("BaseSlackFunctionHandler with inputs and empty outputs", () => {
+  type Inputs = {
+    in: string;
+  };
+  type Outputs = Record<never, never>;
+  const handler: BaseSlackFunctionHandler<Inputs, Outputs> = ({ inputs }) => {
+    const _test = inputs.in;
+
+    return {
+      outputs: {},
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("BaseSlackFunctionHandler with empty inputs and outputs", () => {
+  type Inputs = Record<never, never>;
+  type Outputs = {
+    out: string;
+  };
+  const handler: BaseSlackFunctionHandler<Inputs, Outputs> = () => {
+    return {
+      outputs: {
+        out: "test",
+      },
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("BaseSlackFunctionHandler with any inputs and any outputs", () => {
+  // deno-lint-ignore no-explicit-any
+  const handler: BaseSlackFunctionHandler<any, any> = ({ inputs }) => {
+    return {
+      outputs: {
+        out: inputs.in,
+      },
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("BaseSlackFunctionHandler with set inputs and any outputs", () => {
+  type Inputs = {
+    in: string;
+  };
+  // deno-lint-ignore no-explicit-any
+  const handler: BaseSlackFunctionHandler<Inputs, any> = ({ inputs }) => {
+    return {
+      outputs: {
+        out: inputs.in,
+      },
+    };
+  };
+  assertEquals(typeof handler, "function");
+});

--- a/src/functions/function_tester.ts
+++ b/src/functions/function_tester.ts
@@ -1,6 +1,10 @@
 import type { FunctionContext } from "./types.ts";
-type SlackFunctionTesterArgs<InputParameters> =
-  & Partial<FunctionContext<InputParameters>>
+type SlackFunctionTesterArgs<
+  InputParameters,
+> =
+  & Partial<
+    FunctionContext<InputParameters>
+  >
   & {
     inputs: InputParameters;
   };
@@ -15,9 +19,9 @@ export const SlackFunctionTester = (callbackId: string) => {
     const ts = new Date();
 
     return {
-      inputs: args.inputs,
-      env: args.env || {},
+      inputs: (args.inputs || {}) as InputParameters,
       token: args.token || "slack-function-test-token",
+      env: args.env || {},
       event: args.event || {
         type: "function_executed",
         event_ts: `${ts.getTime()}`,

--- a/src/functions/function_tester.ts
+++ b/src/functions/function_tester.ts
@@ -20,8 +20,8 @@ export const SlackFunctionTester = (callbackId: string) => {
 
     return {
       inputs: (args.inputs || {}) as InputParameters,
-      token: args.token || "slack-function-test-token",
       env: args.env || {},
+      token: args.token || "slack-function-test-token",
       event: args.event || {
         type: "function_executed",
         event_ts: `${ts.getTime()}`,

--- a/src/functions/function_tester_test.ts
+++ b/src/functions/function_tester_test.ts
@@ -18,3 +18,16 @@ Deno.test("SlackFunctionTester.createContext", () => {
   assertEquals(ctx.event.type, "function_executed");
   assertEquals(ctx.event.function.callback_id, callbackId);
 });
+
+Deno.test("SlackFunctionTester.createContext with empty inputs", () => {
+  const callbackId = "my_callback_id";
+  const { createContext } = SlackFunctionTester(callbackId);
+
+  const ctx = createContext({ inputs: {} });
+
+  assertEquals(ctx.inputs, {});
+  assertEquals(ctx.env, {});
+  assertEquals(typeof ctx.token, "string");
+  assertEquals(ctx.event.type, "function_executed");
+  assertEquals(ctx.event.function.callback_id, callbackId);
+});

--- a/src/functions/slack_function_handler_type_test.ts
+++ b/src/functions/slack_function_handler_type_test.ts
@@ -1,11 +1,12 @@
 import { assertEquals } from "../dev_deps.ts";
+import { SlackFunctionTester } from "./function_tester.ts";
 import { DefineFunction } from "./mod.ts";
 import { SlackFunctionHandler } from "./types.ts";
 
 // These tests are to ensure our Function Handler types are supporting the use cases we want to
 // Any "failures" here will most likely be reflected in Type errors
 
-Deno.test("SlackFunctionHandler types", () => {
+Deno.test("SlackFunctionHandler with inputs and outputs", () => {
   const TestFn = DefineFunction({
     callback_id: "test",
     title: "test fn",
@@ -36,7 +37,47 @@ Deno.test("SlackFunctionHandler types", () => {
       },
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const inputs = { in: "test" };
+  const result = handler(createContext({ inputs }));
+  assertEquals(result.outputs?.out, inputs.in);
+});
+
+Deno.test("SlackFunctionHandler with optional input", () => {
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+    input_parameters: {
+      properties: {
+        in: {
+          type: "string",
+        },
+      },
+      required: [],
+    },
+    output_parameters: {
+      properties: {
+        out: {
+          type: "string",
+        },
+      },
+      required: ["out"],
+    },
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = (
+    { inputs },
+  ) => {
+    return {
+      outputs: {
+        out: inputs.in || "default",
+      },
+    };
+  };
+  const { createContext } = SlackFunctionTester("test");
+  const inputs = {};
+  const result = handler(createContext({ inputs }));
+  assertEquals(result.outputs?.out, "default");
 });
 
 Deno.test("SlackFunctionHandler with no inputs or outputs", () => {
@@ -50,7 +91,9 @@ Deno.test("SlackFunctionHandler with no inputs or outputs", () => {
       outputs: {},
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const result = handler(createContext({ inputs: {} }));
+  assertEquals(result.outputs, {});
 });
 
 Deno.test("SlackFunctionHandler with undefined inputs and outputs", () => {
@@ -66,7 +109,9 @@ Deno.test("SlackFunctionHandler with undefined inputs and outputs", () => {
       outputs: {},
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const result = handler(createContext({ inputs: {} }));
+  assertEquals(result.outputs, {});
 });
 
 Deno.test("SlackFunctionHandler with empty inputs and outputs", () => {
@@ -82,7 +127,9 @@ Deno.test("SlackFunctionHandler with empty inputs and outputs", () => {
       outputs: {},
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const result = handler(createContext({ inputs: {} }));
+  assertEquals(result.outputs, {});
 });
 
 Deno.test("SlackFunctionHandler with only inputs", () => {
@@ -108,7 +155,10 @@ Deno.test("SlackFunctionHandler with only inputs", () => {
       outputs: {},
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const inputs = { in: "test" };
+  const result = handler(createContext({ inputs }));
+  assertEquals(result.outputs, {});
 });
 
 Deno.test("SlackFunctionHandler with only outputs", () => {
@@ -132,5 +182,7 @@ Deno.test("SlackFunctionHandler with only outputs", () => {
       },
     };
   };
-  assertEquals(typeof handler, "function");
+  const { createContext } = SlackFunctionTester("test");
+  const result = handler(createContext({ inputs: {} }));
+  assertEquals(result.outputs?.out, "test");
 });

--- a/src/functions/slack_function_handler_type_test.ts
+++ b/src/functions/slack_function_handler_type_test.ts
@@ -1,0 +1,136 @@
+import { assertEquals } from "../dev_deps.ts";
+import { DefineFunction } from "./mod.ts";
+import { SlackFunctionHandler } from "./types.ts";
+
+// These tests are to ensure our Function Handler types are supporting the use cases we want to
+// Any "failures" here will most likely be reflected in Type errors
+
+Deno.test("SlackFunctionHandler types", () => {
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+    input_parameters: {
+      properties: {
+        in: {
+          type: "string",
+        },
+      },
+      required: ["in"],
+    },
+    output_parameters: {
+      properties: {
+        out: {
+          type: "string",
+        },
+      },
+      required: ["out"],
+    },
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = (
+    { inputs },
+  ) => {
+    return {
+      outputs: {
+        out: inputs.in,
+      },
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("SlackFunctionHandler with no inputs or outputs", () => {
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = () => {
+    return {
+      outputs: {},
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("SlackFunctionHandler with undefined inputs and outputs", () => {
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+    input_parameters: undefined,
+    output_parameters: undefined,
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = () => {
+    return {
+      outputs: {},
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("SlackFunctionHandler with empty inputs and outputs", () => {
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+    input_parameters: { properties: {}, required: [] },
+    output_parameters: { properties: {}, required: [] },
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = () => {
+    return {
+      outputs: {},
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("SlackFunctionHandler with only inputs", () => {
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+    input_parameters: {
+      properties: {
+        in: {
+          type: "string",
+        },
+      },
+      required: ["in"],
+    },
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = (
+    { inputs },
+  ) => {
+    const _test = inputs.in;
+
+    return {
+      outputs: {},
+    };
+  };
+  assertEquals(typeof handler, "function");
+});
+
+Deno.test("SlackFunctionHandler with only outputs", () => {
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+    output_parameters: {
+      properties: {
+        out: {
+          type: "string",
+        },
+      },
+      required: ["out"],
+    },
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = () => {
+    return {
+      outputs: {
+        out: "test",
+      },
+    };
+  };
+  assertEquals(typeof handler, "function");
+});

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -104,14 +104,14 @@ export type SlackFunctionHandler<Definition> = Definition extends
  * @description Slack Function handler from input and output types directly
  */
 export type BaseSlackFunctionHandler<
-  InputParameters extends FunctionInputOutputParameters,
-  OutputParameters extends FunctionInputOutputParameters,
+  InputParameters extends FunctionParameters,
+  OutputParameters extends FunctionParameters,
 > =
   | AsyncFunctionHandler<InputParameters, OutputParameters>
   | SyncFunctionHandler<InputParameters, OutputParameters>;
 
 type SuccessfulFunctionReturnArgs<
-  OutputParameters extends FunctionInputOutputParameters,
+  OutputParameters extends FunctionParameters,
 > = {
   completed?: boolean;
   // Allow function to return an empty object if no outputs are defined
@@ -137,7 +137,7 @@ export type FunctionHandlerReturnArgs<
   | ErroredFunctionReturnArgs<OutputParameters>;
 
 export type FunctionContext<
-  InputParameters extends FunctionInputOutputParameters,
+  InputParameters extends FunctionParameters,
 > = {
   /**
    * @description A map of string keys to string values containing any environment variables available and provided to your function handler's execution context.
@@ -152,7 +152,7 @@ export type FunctionContext<
 };
 
 // Allow undefined here for functions that have no inputs and/or outputs
-export type FunctionInputOutputParameters = {
+export type FunctionParameters = {
   // deno-lint-ignore no-explicit-any
   [key: string]: any;
 } | undefined;

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -17,9 +17,7 @@ export type ParameterSetDefinition = {
 
 export type RequiredParameters<
   ParameterSetInternal extends ParameterSetDefinition,
-> = {
-  [index: number]: keyof ParameterSetInternal;
-};
+> = (keyof ParameterSetInternal)[];
 
 export type ParameterPropertiesDefinition<
   Parameters extends ParameterSetDefinition,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,10 @@ import type { ICustomType } from "./types/types.ts";
 // SlackManifestType is the top level type that imports all resources for the app
 // An app manifest is generated based on what this has defined in it
 
-export type { FunctionHandler } from "./functions/types.ts";
+export type {
+  FunctionHandler,
+  SlackFunctionHandler,
+} from "./functions/types.ts";
 export type SlackManifestType = {
   name: string;
   backgroundColor?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,7 @@ import type { ICustomType } from "./types/types.ts";
 
 export type {
   BaseSlackFunctionHandler,
-  //Deprecated - use either SlackFunctionHandler<Definition> or BaseSlackFunctionHandler<Inputs, Outputs>
-  FunctionHandler,
+  FunctionHandler, // Deprecated
   SlackFunctionHandler,
 } from "./functions/types.ts";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,12 @@ import type { ICustomType } from "./types/types.ts";
 // An app manifest is generated based on what this has defined in it
 
 export type {
+  BaseSlackFunctionHandler,
+  //Deprecated - use either SlackFunctionHandler<Definition> or BaseSlackFunctionHandler<Inputs, Outputs>
   FunctionHandler,
   SlackFunctionHandler,
 } from "./functions/types.ts";
+
 export type SlackManifestType = {
   name: string;
   backgroundColor?: string;


### PR DESCRIPTION
## Summary
This PR aims to provide a low-effort solution for developers to write typed function handlers.

```ts
// Define a function in `manifest.ts`
export const ReverseFunction = DefineFunction({...});


// then in your function handler file...

import type { SlackFunctionHandler } from "deno-slack-sdk/types.ts";
// in your function source file, import it as a type to reference in the handler type
import type {ReverseFunction } from "../manifest.ts";

// use the new SlackFunctionHandler type w/ a typeof against the function definition property
const ReverseString: SlackFunctionHandler<typeof ReverseFunction.definition> = (
  { inputs },
) => {
  //...

  return {
    outputs: {
      //...
    },
  };
};
```

This will keep the function typed so it matches the definition without the need to duplicate or generate any static types. Some additional and related functionality I included in this work:

* `inputs` now have runtime properties that are mapped against the `type` of the parameter, i.e. `"string" === string` at runtime. Currently just supporting `string`, `boolean` and `array` types, but we can add additional support as it's added to the type system.
* fixed some edge cases around functions that don't have `input_parameters` or `output_parameters`.

I built the new `SlackFunctionHandler<Definition>` type on top of the existing `FunctionHandler<Inputs, Outputs>` type, but ended up renaming it to `BaseSlackFunctionHandler<Inputs, Outputs>` for a more consistent name. Our documentation can clarify that if developers aren't using the SDK, or want to provide their own Typescript types for the inputs and outputs directly, then can use the lower-level `BaseSlackFunctionHandler` type directly. I've also left the `FunctionHandler` type as an alias to `BaseSlackFunctionHandler` but flagged it as deprecated.

## Testing
I've added a handful of tests for both `SlackFunctionHandler` and `BaseSlackFunctionHandler` types to be explicit about the behavior we support and catch any related type errors.

Using this branch of the SDK against a project, and trying out different input and output parameters is the easiest way to manually test the changes. Functionally not much changes, it's almost purely type changes.