### PR TITLE
Workflow Definition support

### DIFF
--- a/src/functions/mod.ts
+++ b/src/functions/mod.ts
@@ -1,7 +1,7 @@
 import { ManifestFunctionSchema } from "../types.ts";
 import {
   ParameterSetDefinition,
-  RequiredParameters,
+  PossibleParameterKeys,
 } from "../parameters/mod.ts";
 import { FunctionDefinitionArgs } from "./types.ts";
 import { SlackManifest } from "../manifest.ts";
@@ -15,8 +15,8 @@ import { SlackManifest } from "../manifest.ts";
 export const DefineFunction = <
   InputParameters extends ParameterSetDefinition,
   OutputParameters extends ParameterSetDefinition,
-  RequiredInput extends RequiredParameters<InputParameters>,
-  RequiredOutput extends RequiredParameters<OutputParameters>,
+  RequiredInput extends PossibleParameterKeys<InputParameters>,
+  RequiredOutput extends PossibleParameterKeys<OutputParameters>,
 >(
   definition: FunctionDefinitionArgs<
     InputParameters,
@@ -31,8 +31,8 @@ export const DefineFunction = <
 export class SlackFunction<
   InputParameters extends ParameterSetDefinition,
   OutputParameters extends ParameterSetDefinition,
-  RequiredInput extends RequiredParameters<InputParameters>,
-  RequiredOutput extends RequiredParameters<OutputParameters>,
+  RequiredInput extends PossibleParameterKeys<InputParameters>,
+  RequiredOutput extends PossibleParameterKeys<OutputParameters>,
 > {
   public id: string;
 

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -1,6 +1,7 @@
 import { Env, ManifestFunctionSchema } from "../types.ts";
 import {
   ParameterDefinition,
+  ParameterPropertiesDefinition,
   ParameterSetDefinition,
   RequiredParameters,
 } from "../parameters/mod.ts";
@@ -177,7 +178,7 @@ export interface ISlackFunction<
 export type FunctionDefinitionArgs<
   InputParameters extends ParameterSetDefinition,
   OutputParameters extends ParameterSetDefinition,
-  RequiredInput extends RequiredParameters<InputParameters>,
+  RequiredInputs extends RequiredParameters<InputParameters>,
   RequiredOutputs extends RequiredParameters<OutputParameters>,
 > = {
   callback_id: string;
@@ -187,13 +188,13 @@ export type FunctionDefinitionArgs<
   /** An optional description for your function. */
   description?: string;
   /** An optional map of input parameter names containing information about their type, title, description, required and (additional) properties. */
-  "input_parameters"?: {
-    properties: InputParameters;
-    required: RequiredInput;
-  };
+  "input_parameters"?: ParameterPropertiesDefinition<
+    InputParameters,
+    RequiredInputs
+  >;
   /** An optional map of output parameter names containing information about their type, title, description, required and (additional) properties. */
-  "output_parameters"?: {
-    properties: OutputParameters;
-    required: RequiredOutputs;
-  };
+  "output_parameters"?: ParameterPropertiesDefinition<
+    OutputParameters,
+    RequiredOutputs
+  >;
 };

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -3,7 +3,7 @@ import {
   ParameterDefinition,
   ParameterPropertiesDefinition,
   ParameterSetDefinition,
-  RequiredParameters,
+  PossibleParameterKeys,
 } from "../parameters/mod.ts";
 import { TypedArrayParameterDefinition } from "../parameters/types.ts";
 import type SchemaTypes from "../schema/schema_types.ts";
@@ -65,7 +65,7 @@ type TypedArrayFunctionInputRuntimeType<
  */
 type FunctionRuntimeParameters<
   Params extends ParameterSetDefinition,
-  RequiredParams extends RequiredParameters<Params>,
+  RequiredParams extends PossibleParameterKeys<Params>,
 > =
   & {
     [k in RequiredParams[number]]: FunctionInputRuntimeType<
@@ -161,8 +161,8 @@ export type FunctionParameters = {
 export interface ISlackFunction<
   InputParameters extends ParameterSetDefinition,
   OutputParameters extends ParameterSetDefinition,
-  RequiredInput extends RequiredParameters<InputParameters>,
-  RequiredOutputs extends RequiredParameters<OutputParameters>,
+  RequiredInput extends PossibleParameterKeys<InputParameters>,
+  RequiredOutputs extends PossibleParameterKeys<OutputParameters>,
 > {
   id: string;
   definition: FunctionDefinitionArgs<
@@ -178,8 +178,8 @@ export interface ISlackFunction<
 export type FunctionDefinitionArgs<
   InputParameters extends ParameterSetDefinition,
   OutputParameters extends ParameterSetDefinition,
-  RequiredInputs extends RequiredParameters<InputParameters>,
-  RequiredOutputs extends RequiredParameters<OutputParameters>,
+  RequiredInputs extends PossibleParameterKeys<InputParameters>,
+  RequiredOutputs extends PossibleParameterKeys<OutputParameters>,
 > = {
   callback_id: string;
   /** A title for your function. */

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -51,6 +51,13 @@ export class SlackManifest {
       }, {} as ManifestSchema["functions"]);
     }
 
+    if (def.workflows) {
+      manifest.workflows = def.workflows?.reduce((acc = {}, workflow) => {
+        acc[workflow.id] = workflow.export();
+        return acc;
+      }, {} as ManifestSchema["workflows"]);
+    }
+
     if (def.types) {
       manifest.types = def.types?.reduce((acc = {}, customType) => {
         acc[customType.id] = customType.definition;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -69,6 +69,10 @@ export class SlackManifest {
   }
 
   private registerFeatures() {
+    this.definition.workflows?.forEach((workflow) => {
+      workflow.registerStepFunctions(this);
+      workflow.registerParameterTypes(this);
+    });
     // Loop through functions to automatically register any referenced types
     this.definition.functions?.forEach((func) => {
       func.registerParameterTypes(this);

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,5 +1,6 @@
 export { Manifest } from "./manifest.ts";
 export { DefineFunction } from "./functions/mod.ts";
+export { DefineWorkflow } from "./workflows/mod.ts";
 export { DefineType } from "./types/mod.ts";
 export { default as Schema } from "./schema/mod.ts";
 export { DefineDatastore } from "./datastore/mod.ts";

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -15,13 +15,13 @@ export type ParameterSetDefinition = {
   [key: string]: ParameterDefinition;
 };
 
-export type RequiredParameters<
+export type PossibleParameterKeys<
   ParameterSetInternal extends ParameterSetDefinition,
 > = (keyof ParameterSetInternal)[];
 
 export type ParameterPropertiesDefinition<
   Parameters extends ParameterSetDefinition,
-  Required extends RequiredParameters<Parameters>,
+  Required extends PossibleParameterKeys<Parameters>,
 > = {
   properties: Parameters;
   required: Required;

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -21,9 +21,10 @@ export type RequiredParameters<
 
 export type ParameterPropertiesDefinition<
   Parameters extends ParameterSetDefinition,
+  Required extends RequiredParameters<Parameters>,
 > = {
   properties: Parameters;
-  required: RequiredParameters<Parameters>;
+  required: Required;
 };
 
 export type ParameterVariableType<Def extends ParameterDefinition> = Def extends

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -6,7 +6,7 @@ import type {
   // UntypedObjectParameterDefinition,
 } from "./types.ts";
 import { ParamReference } from "./param.ts";
-// import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
+import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
 
 export type ParameterDefinition = TypedParameterDefinition;
 
@@ -39,7 +39,7 @@ export type ParameterVariableType<Def extends ParameterDefinition> = Def extends
 type SingleParameterVariable = {};
 
 // // deno-lint-ignore no-explicit-any
-// type UntypedObjectParameterVariableType = any;
+type UntypedObjectParameterVariableType = any;
 
 // type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
 //   {
@@ -124,16 +124,16 @@ export const ParameterVariable = <P extends ParameterDefinition>(
 //   ) as ObjectParameterVariableType<P>;
 // };
 
-// const CreateUntypedObjectParameterVariable = (
-//   namespace: string,
-//   paramName: string,
-// ): UntypedObjectParameterVariableType => {
-//   return WithUntypedObjectProxy(
-//     {},
-//     namespace,
-//     paramName,
-//   ) as UntypedObjectParameterVariableType;
-// };
+export const CreateUntypedObjectParameterVariable = (
+  namespace: string,
+  paramName: string,
+): UntypedObjectParameterVariableType => {
+  return WithUntypedObjectProxy(
+    {},
+    namespace,
+    paramName,
+  ) as UntypedObjectParameterVariableType;
+};
 
 const CreateSingleParameterVariable = (
   namespace: string,

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -38,7 +38,7 @@ export type ParameterVariableType<Def extends ParameterDefinition> = Def extends
 // deno-lint-ignore ban-types
 type SingleParameterVariable = {};
 
-// // deno-lint-ignore no-explicit-any
+// deno-lint-ignore no-explicit-any
 type UntypedObjectParameterVariableType = any;
 
 // type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { ISlackFunction } from "./functions/types.ts";
+import type { ISlackWorkflow } from "./workflows/types.ts";
 import type { ISlackDatastore } from "./datastore/types.ts";
 import type {
   ParameterDefinition,
@@ -24,6 +25,7 @@ export type SlackManifestType = {
   longDescription?: string;
   botScopes: Array<string>;
   functions?: ManifestFunction[];
+  workflows?: ManifestWorkflow[];
   outgoingDomains?: Array<string>;
   types?: ICustomType[];
   datastores?: ManifestDatastore[];
@@ -35,6 +37,8 @@ export type ManifestDatastore = ISlackDatastore;
 // This is to work around an issue TS has with resolving the generics across the hierarchy
 // deno-lint-ignore no-explicit-any
 export type ManifestFunction = ISlackFunction<any, any, any, any>;
+
+export type ManifestWorkflow = ISlackWorkflow;
 
 // ----------------------------------------------------------------------------
 // Invocation
@@ -94,6 +98,21 @@ export type ManifestDatastoreSchema = {
   };
 };
 
+export type ManifestWorkflowStepSchema = {
+  id: string;
+  "function_id": string;
+  inputs: {
+    [name: string]: unknown;
+  };
+};
+
+export type ManifestWorkflowSchema = {
+  title?: string;
+  description?: string;
+  "input_parameters"?: ManifestFunctionParameters;
+  steps: ManifestWorkflowStepSchema[];
+};
+
 export type ManifestCustomTypeSchema = ParameterDefinition;
 
 export type ManifestMetadata = {
@@ -122,6 +141,9 @@ export type ManifestSchema = {
   };
   functions?: {
     [key: string]: ManifestFunctionSchema;
+  };
+  workflows?: {
+    [key: string]: ManifestWorkflowSchema;
   };
   "outgoing_domains"?: string[];
   types?: {

--- a/src/workflows/mod.ts
+++ b/src/workflows/mod.ts
@@ -1,0 +1,260 @@
+import { SlackManifest } from "../manifest.ts";
+import {
+  ManifestFunction,
+  ManifestWorkflowSchema,
+  ManifestWorkflowStepSchema,
+} from "../types.ts";
+import { ISlackFunction } from "../functions/types.ts";
+import {
+  ParameterSetDefinition,
+  ParameterVariable,
+  ParameterVariableType,
+  RequiredParameters,
+} from "../parameters/mod.ts";
+import {
+  ISlackWorkflow,
+  SlackWorkflowDefinitionArgs,
+  WorkflowInputsOutputsDefinition,
+  WorkflowStepInputs,
+} from "./types.ts";
+
+const localFnPrefix = "#/functions/";
+
+export const DefineWorkflow = <
+  Inputs extends ParameterSetDefinition,
+  Outputs extends ParameterSetDefinition,
+  RequiredInputs extends RequiredParameters<Inputs>,
+  RequiredOutputs extends RequiredParameters<Outputs>,
+>(
+  id: string,
+  definition: SlackWorkflowDefinitionArgs<
+    Inputs,
+    Outputs,
+    RequiredInputs,
+    RequiredOutputs
+  >,
+) => {
+  return new WorkflowDefinition(id, definition);
+};
+
+export class WorkflowDefinition<
+  Inputs extends ParameterSetDefinition,
+  Outputs extends ParameterSetDefinition,
+  RequiredInputs extends RequiredParameters<Inputs>,
+  RequiredOutputs extends RequiredParameters<Outputs>,
+> implements ISlackWorkflow {
+  public id: string;
+  private definition: SlackWorkflowDefinitionArgs<
+    Inputs,
+    Outputs,
+    RequiredInputs,
+    RequiredOutputs
+  >;
+
+  public inputs: WorkflowInputsOutputsDefinition<
+    Inputs
+  >;
+
+  /* this one is a bit tricky, we collect here the workflow steps,
+     these parameters are for the input / output parameters of the function that runs in that step
+     and it's inputs will be of whatever shape, so this can't be typed using the WorkflowDefinition
+     type parameters. The ParameterPropertiesDefinition<T> takes a Parameter set as T and uses that
+     to define the "Required" type. So if we type the below to
+     ParameterPropertiesDefinition<ParameterSetDefinition> it doesn't work, because the required sets
+     of the function could be of a different shape. I couldn't find any way to make this work,
+     other than let that one be `any` type.
+  */
+  steps: WorkflowStepDefinition<
+    // deno-lint-ignore no-explicit-any
+    any,
+    // deno-lint-ignore no-explicit-any
+    any,
+    // deno-lint-ignore no-explicit-any
+    any,
+    // deno-lint-ignore no-explicit-any
+    any
+  >[] = [];
+
+  constructor(
+    id: string,
+    definition: SlackWorkflowDefinitionArgs<
+      Inputs,
+      Outputs,
+      RequiredInputs,
+      RequiredOutputs
+    >,
+  ) {
+    this.id = id;
+    this.definition = definition;
+    this.inputs = {} as WorkflowInputsOutputsDefinition<
+      Inputs
+    >;
+
+    for (
+      const [inputName, inputDefinition] of Object.entries(
+        definition.input_parameters?.properties
+          ? definition.input_parameters.properties
+          : {},
+      )
+    ) {
+      this.inputs[
+        inputName as keyof Inputs
+      ] = ParameterVariable(
+        "inputs",
+        inputName,
+        inputDefinition,
+      ) as ParameterVariableType<
+        Inputs[typeof inputName]
+      >;
+    }
+  }
+
+  addStep<
+    StepInputs extends ParameterSetDefinition,
+    StepOutputs extends ParameterSetDefinition,
+    RequiredStepInputs extends RequiredParameters<StepInputs>,
+    RequiredStepOutputs extends RequiredParameters<StepOutputs>,
+  >(
+    slackFunction: ISlackFunction<
+      StepInputs,
+      StepOutputs,
+      RequiredStepInputs,
+      RequiredStepOutputs
+    >,
+    inputs: WorkflowStepInputs<StepInputs, RequiredStepInputs>,
+  ): WorkflowStepDefinition<
+    StepInputs,
+    StepOutputs,
+    RequiredStepInputs,
+    RequiredStepOutputs
+  > {
+    const stepId = `${this.steps.length}`;
+
+    const newStep = new WorkflowStepDefinition(
+      stepId,
+      slackFunction,
+      inputs,
+    );
+
+    this.steps.push(newStep);
+
+    return newStep;
+  }
+
+  export(): ManifestWorkflowSchema {
+    return {
+      title: this.definition.title,
+      description: this.definition.description,
+      input_parameters: this.definition.input_parameters,
+      steps: this.steps.map((s) => s.export()),
+    };
+  }
+
+  registerStepFunctions(manifest: SlackManifest) {
+    this.steps.forEach((s) => s.registerFunction(manifest));
+  }
+
+  registerParameterTypes(manifest: SlackManifest) {
+    const { input_parameters: inputParams, output_parameters: outputParams } =
+      this.definition;
+    manifest.registerTypes(inputParams?.properties ?? {});
+    manifest.registerTypes(outputParams?.properties ?? {});
+  }
+
+  toJSON() {
+    return this.export();
+  }
+}
+
+class WorkflowStepDefinition<
+  InputParameters extends ParameterSetDefinition,
+  OutputParameters extends ParameterSetDefinition,
+  RequiredInputs extends RequiredParameters<InputParameters>,
+  RequiredOutputs extends RequiredParameters<OutputParameters>,
+> {
+  private stepId: string;
+
+  public definition: ISlackFunction<
+    InputParameters,
+    OutputParameters,
+    RequiredInputs,
+    RequiredOutputs
+  >;
+
+  private inputs: WorkflowStepInputs<InputParameters, RequiredInputs>;
+
+  public outputs: WorkflowInputsOutputsDefinition<
+    OutputParameters
+  >;
+  private fnRef: string;
+  constructor(
+    stepId: string,
+    slackFunction: ISlackFunction<
+      InputParameters,
+      OutputParameters,
+      RequiredInputs,
+      RequiredOutputs
+    >,
+    inputs: WorkflowStepInputs<InputParameters, RequiredInputs>,
+  ) {
+    this.stepId = stepId;
+    this.definition = slackFunction;
+    this.inputs = inputs;
+    this.outputs = {} as WorkflowInputsOutputsDefinition<
+      OutputParameters
+    >;
+    const fnId = this.definition.id;
+    // TODO: This is hacky, will revamp this later to allow fns to handle namespaces
+    this.fnRef = /^slack#/.test(fnId) ? fnId : localFnPrefix + fnId;
+
+    // Setup step outputs for use in input template expressions
+    for (
+      const [outputName, outputDefinition] of Object.entries(
+        slackFunction?.definition?.output_parameters?.properties ?? {},
+      )
+    ) {
+      this.outputs[
+        outputName as keyof OutputParameters
+      ] = ParameterVariable(
+        `steps.${this.stepId}`,
+        outputName,
+        outputDefinition,
+      ) as ParameterVariableType<
+        OutputParameters[typeof outputName]
+      >;
+    }
+  }
+
+  templatizeInputs() {
+    const templatizedInputs: ManifestWorkflowStepSchema["inputs"] =
+      {} as ManifestWorkflowStepSchema["inputs"];
+
+    for (const [inputName, inputValue] of Object.entries(this.inputs)) {
+      templatizedInputs[inputName] = JSON.parse(JSON.stringify(inputValue));
+    }
+
+    return templatizedInputs;
+  }
+
+  export(): ManifestWorkflowStepSchema {
+    return {
+      id: this.stepId,
+      function_id: this.fnRef,
+      inputs: this.templatizeInputs(),
+    };
+  }
+
+  toJSON() {
+    return this.export();
+  }
+
+  registerFunction(manifest: SlackManifest) {
+    if (this.isLocalFunctionReference()) {
+      manifest.registerFunction(this.definition as ManifestFunction);
+    }
+  }
+
+  private isLocalFunctionReference(): boolean {
+    return this.fnRef.startsWith(localFnPrefix);
+  }
+}

--- a/src/workflows/mod.ts
+++ b/src/workflows/mod.ts
@@ -54,25 +54,6 @@ export class WorkflowDefinition<
   >;
 
   steps: BaseWorkflowStepDefinition[] = [];
-  /* this one is a bit tricky, we collect here the workflow steps,
-     these parameters are for the input / output parameters of the function that runs in that step
-     and it's inputs will be of whatever shape, so this can't be typed using the WorkflowDefinition
-     type parameters. The ParameterPropertiesDefinition<T> takes a Parameter set as T and uses that
-     to define the "Required" type. So if we type the below to
-     ParameterPropertiesDefinition<ParameterSetDefinition> it doesn't work, because the required sets
-     of the function could be of a different shape. I couldn't find any way to make this work,
-     other than let that one be `any` type.
-  */
-  // steps: WorkflowStepDefinition<
-  //   // deno-lint-ignore no-explicit-any
-  //   any,
-  //   // deno-lint-ignore no-explicit-any
-  //   any,
-  //   // deno-lint-ignore no-explicit-any
-  //   any,
-  //   // deno-lint-ignore no-explicit-any
-  //   any
-  // >[] = [];
 
   constructor(
     definition: SlackWorkflowDefinitionArgs<

--- a/src/workflows/mod.ts
+++ b/src/workflows/mod.ts
@@ -102,19 +102,9 @@ export class WorkflowDefinition<
     }
   }
 
-  // Supports adding an untyped step by using a plain function reference string and input configuration
-  // This won't support any typed inputs or outputs on the step, but can be useful when adding a step w/o the type definition available
-  addStep(
-    functionReference: string,
-    // This is essentially an untyped step input configuration
-    inputs: WorkflowStepInputs<
-      ParameterSetDefinition,
-      RequiredParameters<ParameterSetDefinition>
-    >,
-  ): UntypedWorkflowStepDefinition;
-
   // Supports adding a typed step where an ISlackFunction reference is used, which produces typed inputs and outputs
   // and the functionReference string can be rerived from that ISlackFunction reference
+  // Important that this overload is 1st, as it's the more specific match, and preffered type if it matches
   addStep<
     StepInputs extends ParameterSetDefinition,
     StepOutputs extends ParameterSetDefinition,
@@ -134,6 +124,17 @@ export class WorkflowDefinition<
     RequiredStepInputs,
     RequiredStepOutputs
   >;
+
+  // Supports adding an untyped step by using a plain function reference string and input configuration
+  // This won't support any typed inputs or outputs on the step, but can be useful when adding a step w/o the type definition available
+  addStep(
+    functionReference: string,
+    // This is essentially an untyped step input configuration
+    inputs: WorkflowStepInputs<
+      ParameterSetDefinition,
+      RequiredParameters<ParameterSetDefinition>
+    >,
+  ): UntypedWorkflowStepDefinition;
 
   // The runtime implementation of addStep handles both signatures (straight function-reference & config, or ISlackFunction)
   addStep<

--- a/src/workflows/mod.ts
+++ b/src/workflows/mod.ts
@@ -8,14 +8,15 @@ import {
   RequiredParameters,
 } from "../parameters/mod.ts";
 import {
-  BaseWorkflowStepDefinition,
+  TypedWorkflowStepDefinition,
   UntypedWorkflowStepDefinition,
   WorkflowStepDefinition,
 } from "./workflow-step.ts";
 import {
   ISlackWorkflow,
   SlackWorkflowDefinitionArgs,
-  WorkflowInputsOutputsDefinition,
+  WorkflowInputs,
+  WorkflowOutputs,
   WorkflowStepInputs,
 } from "./types.ts";
 
@@ -49,11 +50,17 @@ export class WorkflowDefinition<
     RequiredOutputs
   >;
 
-  public inputs: WorkflowInputsOutputsDefinition<
-    Inputs
+  public inputs: WorkflowInputs<
+    Inputs,
+    RequiredInputs
   >;
 
-  steps: BaseWorkflowStepDefinition[] = [];
+  public outputs: WorkflowOutputs<
+    Outputs,
+    RequiredOutputs
+  >;
+
+  steps: WorkflowStepDefinition[] = [];
 
   constructor(
     definition: SlackWorkflowDefinitionArgs<
@@ -65,8 +72,13 @@ export class WorkflowDefinition<
   ) {
     this.id = definition.callback_id;
     this.definition = definition;
-    this.inputs = {} as WorkflowInputsOutputsDefinition<
-      Inputs
+    this.inputs = {} as WorkflowInputs<
+      Inputs,
+      RequiredInputs
+    >;
+    this.outputs = {} as WorkflowOutputs<
+      Outputs,
+      RequiredOutputs
     >;
 
     for (
@@ -76,6 +88,8 @@ export class WorkflowDefinition<
           : {},
       )
     ) {
+      // deno-lint-ignore ban-ts-comment
+      //@ts-ignore
       this.inputs[
         inputName as keyof Inputs
       ] = ParameterVariable(
@@ -114,7 +128,7 @@ export class WorkflowDefinition<
       RequiredStepOutputs
     >,
     inputs: WorkflowStepInputs<StepInputs, RequiredStepInputs>,
-  ): WorkflowStepDefinition<
+  ): TypedWorkflowStepDefinition<
     StepInputs,
     StepOutputs,
     RequiredStepInputs,
@@ -137,7 +151,7 @@ export class WorkflowDefinition<
         RequiredStepOutputs
       >,
     inputs: WorkflowStepInputs<StepInputs, RequiredStepInputs>,
-  ): BaseWorkflowStepDefinition {
+  ): WorkflowStepDefinition {
     const stepId = `${this.steps.length}`;
 
     if (typeof functionOrReference === "string") {
@@ -156,7 +170,7 @@ export class WorkflowDefinition<
       RequiredStepInputs,
       RequiredStepOutputs
     >;
-    const newStep = new WorkflowStepDefinition(
+    const newStep = new TypedWorkflowStepDefinition(
       stepId,
       slackFunction,
       inputs,

--- a/src/workflows/mod.ts
+++ b/src/workflows/mod.ts
@@ -5,7 +5,7 @@ import {
   ParameterSetDefinition,
   ParameterVariable,
   ParameterVariableType,
-  RequiredParameters,
+  PossibleParameterKeys,
 } from "../parameters/mod.ts";
 import {
   TypedWorkflowStepDefinition,
@@ -23,8 +23,8 @@ import {
 export const DefineWorkflow = <
   Inputs extends ParameterSetDefinition,
   Outputs extends ParameterSetDefinition,
-  RequiredInputs extends RequiredParameters<Inputs>,
-  RequiredOutputs extends RequiredParameters<Outputs>,
+  RequiredInputs extends PossibleParameterKeys<Inputs>,
+  RequiredOutputs extends PossibleParameterKeys<Outputs>,
 >(
   definition: SlackWorkflowDefinitionArgs<
     Inputs,
@@ -39,8 +39,8 @@ export const DefineWorkflow = <
 export class WorkflowDefinition<
   Inputs extends ParameterSetDefinition,
   Outputs extends ParameterSetDefinition,
-  RequiredInputs extends RequiredParameters<Inputs>,
-  RequiredOutputs extends RequiredParameters<Outputs>,
+  RequiredInputs extends PossibleParameterKeys<Inputs>,
+  RequiredOutputs extends PossibleParameterKeys<Outputs>,
 > implements ISlackWorkflow {
   public id: string;
   private definition: SlackWorkflowDefinitionArgs<
@@ -108,8 +108,8 @@ export class WorkflowDefinition<
   addStep<
     StepInputs extends ParameterSetDefinition,
     StepOutputs extends ParameterSetDefinition,
-    RequiredStepInputs extends RequiredParameters<StepInputs>,
-    RequiredStepOutputs extends RequiredParameters<StepOutputs>,
+    RequiredStepInputs extends PossibleParameterKeys<StepInputs>,
+    RequiredStepOutputs extends PossibleParameterKeys<StepOutputs>,
   >(
     slackFunction: ISlackFunction<
       StepInputs,
@@ -132,7 +132,7 @@ export class WorkflowDefinition<
     // This is essentially an untyped step input configuration
     inputs: WorkflowStepInputs<
       ParameterSetDefinition,
-      RequiredParameters<ParameterSetDefinition>
+      PossibleParameterKeys<ParameterSetDefinition>
     >,
   ): UntypedWorkflowStepDefinition;
 
@@ -140,8 +140,8 @@ export class WorkflowDefinition<
   addStep<
     StepInputs extends ParameterSetDefinition,
     StepOutputs extends ParameterSetDefinition,
-    RequiredStepInputs extends RequiredParameters<StepInputs>,
-    RequiredStepOutputs extends RequiredParameters<StepOutputs>,
+    RequiredStepInputs extends PossibleParameterKeys<StepInputs>,
+    RequiredStepOutputs extends PossibleParameterKeys<StepOutputs>,
   >(
     functionOrReference:
       | string

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -67,7 +67,7 @@ type WorkflowParameterReferences<
   };
 
 // Workflow Step inputs are different than workflow inputs/outputs or workflow step outputs.
-// They are purley the config values for the step, and not definitions that can be referenced
+// They are purely the config values for the step, and not definitions that can be referenced
 // as variables like you can with workflow inputs and workflow step outputs
 export type WorkflowStepInputs<
   InputParameters extends ParameterSetDefinition,

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -4,7 +4,7 @@ import {
   ParameterPropertiesDefinition,
   ParameterSetDefinition,
   ParameterVariableType,
-  RequiredParameters,
+  PossibleParameterKeys,
 } from "../parameters/mod.ts";
 
 export interface ISlackWorkflow {
@@ -22,8 +22,8 @@ export type SlackWorkflowDefinition<Definition> = Definition extends
 export type SlackWorkflowDefinitionArgs<
   InputParameters extends ParameterSetDefinition,
   OutputParameters extends ParameterSetDefinition,
-  RequiredInputs extends RequiredParameters<InputParameters>,
-  RequiredOutputs extends RequiredParameters<OutputParameters>,
+  RequiredInputs extends PossibleParameterKeys<InputParameters>,
+  RequiredOutputs extends PossibleParameterKeys<OutputParameters>,
 > = {
   callback_id: string;
   title: string;
@@ -40,22 +40,22 @@ export type SlackWorkflowDefinitionArgs<
 
 export type WorkflowInputs<
   Params extends ParameterSetDefinition,
-  RequiredParams extends RequiredParameters<Params>,
+  RequiredParams extends PossibleParameterKeys<Params>,
 > = WorkflowParameterReferences<Params, RequiredParams>;
 
 export type WorkflowOutputs<
   Params extends ParameterSetDefinition,
-  RequiredParams extends RequiredParameters<Params>,
+  RequiredParams extends PossibleParameterKeys<Params>,
 > = WorkflowParameterReferences<Params, RequiredParams>;
 
 export type WorkflowStepOutputs<
   Params extends ParameterSetDefinition,
-  RequiredParams extends RequiredParameters<Params>,
+  RequiredParams extends PossibleParameterKeys<Params>,
 > = WorkflowParameterReferences<Params, RequiredParams>;
 
 type WorkflowParameterReferences<
   Parameters extends ParameterSetDefinition,
-  Required extends RequiredParameters<Parameters>,
+  Required extends PossibleParameterKeys<Parameters>,
 > =
   & {
     [name in Required[number]]: ParameterVariableType<
@@ -71,7 +71,7 @@ type WorkflowParameterReferences<
 // as variables like you can with workflow inputs and workflow step outputs
 export type WorkflowStepInputs<
   InputParameters extends ParameterSetDefinition,
-  RequiredInputs extends RequiredParameters<InputParameters>,
+  RequiredInputs extends PossibleParameterKeys<InputParameters>,
 > =
   & {
     // deno-lint-ignore no-explicit-any

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -1,0 +1,9 @@
+import { SlackManifest } from "../manifest.ts";
+import type { ManifestWorkflowSchema } from "../types.ts";
+
+export interface ISlackWorkflow {
+  id: string;
+  export: () => ManifestWorkflowSchema;
+  registerStepFunctions: (manifest: SlackManifest) => void;
+  registerParameterTypes: (manfest: SlackManifest) => void;
+}

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -1,5 +1,10 @@
 import { SlackManifest } from "../manifest.ts";
 import type { ManifestWorkflowSchema } from "../types.ts";
+import {
+  ParameterSetDefinition,
+  ParameterVariableType,
+  RequiredParameters,
+} from "../parameters/mod.ts";
 
 export interface ISlackWorkflow {
   id: string;
@@ -7,3 +12,50 @@ export interface ISlackWorkflow {
   registerStepFunctions: (manifest: SlackManifest) => void;
   registerParameterTypes: (manfest: SlackManifest) => void;
 }
+
+export type SlackWorkflowDefinitionArgs<
+  InputParameters extends ParameterSetDefinition,
+  OutputParameters extends ParameterSetDefinition,
+  RequiredInputs extends RequiredParameters<InputParameters>,
+  RequiredOutputs extends RequiredParameters<OutputParameters>,
+> = {
+  title: string;
+  description?: string;
+  "input_parameters"?: {
+    required: RequiredInputs;
+    properties: InputParameters;
+  };
+  "output_parameters"?: {
+    required: RequiredOutputs;
+    properties: OutputParameters;
+  };
+};
+
+export type WorkflowInputsOutputsDefinition<
+  Parameters extends ParameterSetDefinition,
+> = {
+  [name in keyof Parameters]: ParameterVariableType<
+    Parameters[name]
+  >;
+};
+
+export type WorkflowStepInputs<
+  InputParameters extends ParameterSetDefinition,
+  RequiredInputs extends RequiredParameters<InputParameters>,
+> =
+  & {
+    // deno-lint-ignore no-explicit-any
+    [k in RequiredInputs[number]]: any;
+  }
+  & {
+    // deno-lint-ignore no-explicit-any
+    [k in keyof InputParameters]?: any;
+  };
+
+// export type SlackWorkflow<Definition> = Definition extends
+//   SlackWorkflowDefinitionArgs<infer I, infer O, infer RI, infer RO>
+//   ? BaseSlackFunctionHandler<
+//     FunctionRuntimeParameters<I, RI>,
+//     FunctionRuntimeParameters<O, RO>
+//   >
+//   : never;

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -19,6 +19,7 @@ export type SlackWorkflowDefinitionArgs<
   RequiredInputs extends RequiredParameters<InputParameters>,
   RequiredOutputs extends RequiredParameters<OutputParameters>,
 > = {
+  callback_id: string;
   title: string;
   description?: string;
   "input_parameters"?: {

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -72,10 +72,12 @@ type WorkflowParameterReferences<
 export type WorkflowStepInputs<
   InputParameters extends ParameterSetDefinition,
   RequiredInputs extends RequiredParameters<InputParameters>,
-> = // & {
-  //   [k in RequiredInputs[number]]: any;
-  // }
-  {
+> =
+  & {
+    // deno-lint-ignore no-explicit-any
+    [k in RequiredInputs[number]]: any;
+  }
+  & {
     // deno-lint-ignore no-explicit-any
     [k in keyof InputParameters]?: any;
   };

--- a/src/workflows/workflow-step.ts
+++ b/src/workflows/workflow-step.ts
@@ -1,0 +1,145 @@
+import { SlackManifest } from "../manifest.ts";
+import { ManifestFunction, ManifestWorkflowStepSchema } from "../types.ts";
+import { ISlackFunction } from "../functions/types.ts";
+import {
+  CreateUntypedObjectParameterVariable,
+  ParameterSetDefinition,
+  ParameterVariable,
+  ParameterVariableType,
+  RequiredParameters,
+} from "../parameters/mod.ts";
+import {
+  WorkflowInputsOutputsDefinition,
+  WorkflowStepInputs,
+} from "./types.ts";
+
+const localFnPrefix = "#/functions/";
+
+export abstract class BaseWorkflowStepDefinition {
+  protected stepId: string;
+
+  protected functionReference: string;
+
+  protected inputs: WorkflowStepInputs<any, any>;
+
+  constructor(
+    stepId: string,
+    functionReference: string,
+    inputs: WorkflowStepInputs<any, any>,
+  ) {
+    this.stepId = stepId;
+    // ensures the function reference is a full path - local functions will only be passing in the function callback id
+    this.functionReference = functionReference.includes("#/")
+      ? functionReference
+      : `${localFnPrefix}${functionReference}`;
+    this.inputs = inputs;
+  }
+
+  templatizeInputs() {
+    const templatizedInputs: ManifestWorkflowStepSchema["inputs"] =
+      {} as ManifestWorkflowStepSchema["inputs"];
+
+    for (const [inputName, inputValue] of Object.entries(this.inputs)) {
+      templatizedInputs[inputName] = JSON.parse(JSON.stringify(inputValue));
+    }
+
+    return templatizedInputs;
+  }
+
+  export(): ManifestWorkflowStepSchema {
+    return {
+      id: this.stepId,
+      function_id: this.functionReference,
+      inputs: this.templatizeInputs(),
+    };
+  }
+
+  toJSON() {
+    return this.export();
+  }
+
+  registerFunction(_manifest: SlackManifest) {
+    // default is a noop, only steps using a function definition will register themselves on the manifest
+  }
+
+  protected isLocalFunctionReference(): boolean {
+    return this.functionReference.startsWith(localFnPrefix);
+  }
+}
+
+export class WorkflowStepDefinition<
+  InputParameters extends ParameterSetDefinition,
+  OutputParameters extends ParameterSetDefinition,
+  RequiredInputs extends RequiredParameters<InputParameters>,
+  RequiredOutputs extends RequiredParameters<OutputParameters>,
+> extends BaseWorkflowStepDefinition {
+  public definition: ISlackFunction<
+    InputParameters,
+    OutputParameters,
+    RequiredInputs,
+    RequiredOutputs
+  >;
+
+  public outputs: WorkflowInputsOutputsDefinition<
+    OutputParameters
+  >;
+
+  constructor(
+    stepId: string,
+    slackFunction: ISlackFunction<
+      InputParameters,
+      OutputParameters,
+      RequiredInputs,
+      RequiredOutputs
+    >,
+    inputs: WorkflowStepInputs<InputParameters, RequiredInputs>,
+  ) {
+    super(stepId, slackFunction.id, inputs);
+
+    this.definition = slackFunction;
+
+    this.outputs = {} as WorkflowInputsOutputsDefinition<
+      OutputParameters
+    >;
+
+    // Setup step outputs for use in input template expressions
+    for (
+      const [outputName, outputDefinition] of Object.entries(
+        slackFunction?.definition?.output_parameters?.properties ?? {},
+      )
+    ) {
+      this.outputs[
+        outputName as keyof OutputParameters
+      ] = ParameterVariable(
+        `steps.${this.stepId}`,
+        outputName,
+        outputDefinition,
+      ) as ParameterVariableType<
+        OutputParameters[typeof outputName]
+      >;
+    }
+  }
+
+  registerFunction(manifest: SlackManifest) {
+    if (this.isLocalFunctionReference()) {
+      manifest.registerFunction(this.definition as ManifestFunction);
+    }
+  }
+}
+
+export class UntypedWorkflowStepDefinition extends BaseWorkflowStepDefinition {
+  public outputs: ReturnType<typeof CreateUntypedObjectParameterVariable>;
+
+  constructor(
+    stepId: string,
+    functionReference: string,
+    inputs: WorkflowStepInputs<any, any>,
+  ) {
+    super(stepId, functionReference, inputs);
+
+    this.outputs = CreateUntypedObjectParameterVariable(
+      `steps.${stepId}`,
+      "",
+    );
+  }
+}

--- a/src/workflows/workflow-step.ts
+++ b/src/workflows/workflow-step.ts
@@ -20,11 +20,13 @@ export abstract class BaseWorkflowStepDefinition {
 
   protected functionReference: string;
 
+  // deno-lint-ignore no-explicit-any
   protected inputs: WorkflowStepInputs<any, any>;
 
   constructor(
     stepId: string,
     functionReference: string,
+    // deno-lint-ignore no-explicit-any
     inputs: WorkflowStepInputs<any, any>,
   ) {
     this.stepId = stepId;
@@ -133,6 +135,7 @@ export class UntypedWorkflowStepDefinition extends BaseWorkflowStepDefinition {
   constructor(
     stepId: string,
     functionReference: string,
+    // deno-lint-ignore no-explicit-any
     inputs: WorkflowStepInputs<any, any>,
   ) {
     super(stepId, functionReference, inputs);

--- a/src/workflows/workflow-step.ts
+++ b/src/workflows/workflow-step.ts
@@ -22,14 +22,12 @@ abstract class BaseWorkflowStepDefinition {
 
   protected functionReference: string;
 
-  // deno-lint-ignore no-explicit-any
-  protected inputs: WorkflowStepInputs<any, any>;
+  protected inputs: Record<string, unknown>;
 
   constructor(
     stepId: string,
     functionReference: string,
-    // deno-lint-ignore no-explicit-any
-    inputs: WorkflowStepInputs<any, any>,
+    inputs: Record<string, unknown>,
   ) {
     this.stepId = stepId;
     // ensures the function reference is a full path - local functions will only be passing in the function callback id

--- a/src/workflows/workflow-step.ts
+++ b/src/workflows/workflow-step.ts
@@ -6,7 +6,7 @@ import {
   ParameterSetDefinition,
   ParameterVariable,
   ParameterVariableType,
-  RequiredParameters,
+  PossibleParameterKeys,
 } from "../parameters/mod.ts";
 import { WorkflowStepInputs, WorkflowStepOutputs } from "./types.ts";
 
@@ -74,8 +74,8 @@ abstract class BaseWorkflowStepDefinition {
 export class TypedWorkflowStepDefinition<
   InputParameters extends ParameterSetDefinition,
   OutputParameters extends ParameterSetDefinition,
-  RequiredInputs extends RequiredParameters<InputParameters>,
-  RequiredOutputs extends RequiredParameters<OutputParameters>,
+  RequiredInputs extends PossibleParameterKeys<InputParameters>,
+  RequiredOutputs extends PossibleParameterKeys<OutputParameters>,
 > extends BaseWorkflowStepDefinition {
   public definition: ISlackFunction<
     InputParameters,

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -44,15 +44,18 @@ Deno.test("WorkflowStep export input values", () => {
     },
   });
 
+  // Add a DefineFunction result as a step
   const step1 = workflow.addStep(TestFunction, {
     email: workflow.inputs.email,
     name: `A name: ${workflow.inputs.name}`,
   });
 
+  // add a manually configured step
   const step2 = workflow.addStep("slack#/functions/create_channel", {
-    channel_name: `test-channel-${workflow.inputs.name}`,
+    channel_name: `test-channel-${workflow.inputs.name}-${step1.outputs.url}`,
   });
 
+  // another manually configured step, reyling on outputs of another manually configured step
   workflow.addStep("slack#/functions/send_message", {
     channel_id: "C123123",
     message: `Channel Created <#${step2.outputs.channel_id}>`,
@@ -74,7 +77,10 @@ Deno.test("WorkflowStep export input values", () => {
   assertEquals(`${step1Inputs.name}`, "A name: {{inputs.name}}");
   assertEquals(`${step1.outputs.url}`, "{{steps.0.url}}");
 
-  assertEquals(`${step2Inputs.channel_name}`, "test-channel-{{inputs.name}}");
+  assertEquals(
+    `${step2Inputs.channel_name}`,
+    "test-channel-{{inputs.name}}-{{steps.0.url}}",
+  );
 
   assertEquals(`${step3Inputs.channel_id}`, "C123123");
   assertEquals(

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -40,7 +40,7 @@ Deno.test("WorkflowStep export input values", () => {
           type: "string",
         },
       },
-      required: ["email", "name"],
+      required: ["email"],
     },
   });
 
@@ -60,8 +60,6 @@ Deno.test("WorkflowStep export input values", () => {
     channel_id: "C123123",
     message: `Channel Created <#${step2.outputs.channel_id}>`,
   });
-
-  step2.outputs.message_ts;
 
   const exportedWorkflow = workflow.export();
   const step1Inputs = exportedWorkflow.steps[0].inputs;

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -1,0 +1,62 @@
+import { assertEquals } from "../dev_deps.ts";
+import { DefineWorkflow } from "./mod.ts";
+import { DefineFunction } from "../mod.ts";
+
+Deno.test("WorkflowStep export input values", () => {
+  const TestFunction = DefineFunction({
+    callback_id: "no_params",
+    title: "Test Function",
+    source_file: "",
+    input_parameters: {
+      properties: {
+        email: {
+          type: "string",
+        },
+        name: {
+          type: "string",
+        },
+      },
+      required: ["email"],
+    },
+    output_parameters: {
+      properties: {
+        url: {
+          type: "string",
+        },
+      },
+      required: ["url"],
+    },
+  });
+
+  const workflow = DefineWorkflow("test_wf", {
+    title: "test",
+    input_parameters: {
+      properties: {
+        email: {
+          type: "string",
+        },
+        name: {
+          type: "string",
+        },
+      },
+      required: ["email", "name"],
+    },
+  });
+
+  const step1 = workflow.addStep(TestFunction, {
+    email: workflow.inputs.email,
+    name: `A name: ${workflow.inputs.name}`,
+  });
+
+  const exportedWorkflow = workflow.export();
+  const step1Inputs = exportedWorkflow.steps[0].inputs;
+
+  assertEquals(exportedWorkflow.steps.length, 1);
+  assertEquals(exportedWorkflow.title, "test");
+  assertEquals(exportedWorkflow?.input_parameters?.properties.email, {
+    type: "string",
+  });
+  assertEquals(`${step1Inputs.email}`, "{{inputs.email}}");
+  assertEquals(`${step1Inputs.name}`, "A name: {{inputs.name}}");
+  assertEquals(`${step1.outputs.url}`, "{{steps.0.url}}");
+});

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -28,7 +28,8 @@ Deno.test("WorkflowStep export input values", () => {
     },
   });
 
-  const workflow = DefineWorkflow("test_wf", {
+  const workflow = DefineWorkflow({
+    callback_id: "test_wf",
     title: "test",
     input_parameters: {
       properties: {
@@ -48,10 +49,23 @@ Deno.test("WorkflowStep export input values", () => {
     name: `A name: ${workflow.inputs.name}`,
   });
 
+  const step2 = workflow.addStep("slack#/functions/create_channel", {
+    channel_name: `test-channel-${workflow.inputs.name}`,
+  });
+
+  workflow.addStep("slack#/functions/send_message", {
+    channel_id: "C123123",
+    message: `Channel Created <#${step2.outputs.channel_id}>`,
+  });
+
+  step2.outputs.message_ts;
+
   const exportedWorkflow = workflow.export();
   const step1Inputs = exportedWorkflow.steps[0].inputs;
+  const step2Inputs = exportedWorkflow.steps[1].inputs;
+  const step3Inputs = exportedWorkflow.steps[2].inputs;
 
-  assertEquals(exportedWorkflow.steps.length, 1);
+  assertEquals(exportedWorkflow.steps.length, 3);
   assertEquals(exportedWorkflow.title, "test");
   assertEquals(exportedWorkflow?.input_parameters?.properties.email, {
     type: "string",
@@ -59,4 +73,12 @@ Deno.test("WorkflowStep export input values", () => {
   assertEquals(`${step1Inputs.email}`, "{{inputs.email}}");
   assertEquals(`${step1Inputs.name}`, "A name: {{inputs.name}}");
   assertEquals(`${step1.outputs.url}`, "{{steps.0.url}}");
+
+  assertEquals(`${step2Inputs.channel_name}`, "test-channel-{{inputs.name}}");
+
+  assertEquals(`${step3Inputs.channel_id}`, "C123123");
+  assertEquals(
+    `${step3Inputs.message}`,
+    "Channel Created <#{{steps.1.channel_id}}>",
+  );
 });


### PR DESCRIPTION
## Adding ability to define workflows in your manifest

This exports a `DefineWorkflow()` from the main `mod.ts` file. It will create a workflow definition to be inserted into the `workflows` array in the manifest.

_Example of workflow being defined_
```ts
const ReacjiChannelerWorkflow = DefineWorkflow({
  callback_id: "reacji_channeler",
  title: "Reacji Channeler",
  input_parameters: {
    properties: {
      forward_channel: {
        type: Schema.slack.types.channel_id,
      },
      message_channel: {
        type: Schema.slack.types.channel_id,
      },
      message_ts: {
        type: Schema.types.string,
      },
    },
    required: ["forward_channel", "message_channel", "message_ts"],
  },
});
```

A workflow isn't very fun (or valid) without some steps. Steps can be added by one of two ways:

## 1️⃣ Calling with a typed function definition
This is what you have after calling `DefineFunction()`

```ts
const GetMessagePermalink = DefineFunction(...);

const ReacjiChannelerWorkflow = DefineWorkflow(...);

const step1 = ReacjiChannelerWorkflow.addStep(GetMessagePermalink, {
  channel: ReacjiChannelerWorkflow.inputs.message_channel,
  message_ts: ReacjiChannelerWorkflow.inputs.message_ts,
});
```

## 2️⃣ Using plain function references
You can also add a step to a workflow with the plain function reference string and inputs. This is helpful if you don't have the function definition available in your code. The only disadvantage here is you have to create the function reference string yourself, and your input values object isn't typed for you. Building off our `ReacjiChannelerWorkflow` example, we can add a slack builtin function as a step like so:

```ts
ReacjiChannelerWorkflow.addStep("slack#/functions/send_message", {
  channel_id: ReacjiChannelerWorkflow.inputs.forward_channel,
  message: `Link: ${step1.outputs.permalink}`,
});
```

## Adding your workflow to your manifest

```ts
export default Manifest({
  //...
  workflows: [ReacjiChannelerWorkflow],
});
```


## Testing
* I've added a workflow-level unit test to exercise defining a workflow and adding steps both ways.
* Define and add a workflow to your manifest, then run `hermes manifest` and check your manifest for your new workflow definition.
* You can deploy your app with this `workflow` in your manifest, which does accept a valid workflow, but we aren't quite ready to test running a workflow defined in the manifest. I would consider the manifest updating with your workflow as a success for now.
