### PR TITLE
Remove callback_id from the type we export to the manifest

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -53,7 +53,6 @@ export class SlackManifest {
 
     if (def.types) {
       manifest.types = def.types?.reduce((acc = {}, customType) => {
-        // remove callback_id from the definition we pass to the manifest
         acc[customType.id] = customType.export();
         return acc;
       }, {} as ManifestSchema["types"]);

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -53,7 +53,8 @@ export class SlackManifest {
 
     if (def.types) {
       manifest.types = def.types?.reduce((acc = {}, customType) => {
-        acc[customType.id] = customType.definition;
+        // remove callback_id from the definition we pass to the manifest
+        acc[customType.id] = customType.export();
         return acc;
       }, {} as ManifestSchema["types"]);
     }

--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -93,9 +93,9 @@ Deno.test("Manifest() automatically registers types used by function input and o
     CustomStringType,
   ]);
   assertEquals(manifest.types, {
-    [inputTypeId]: CustomInputType.definition,
-    [stringTypeId]: CustomStringType.definition,
-    [outputTypeId]: CustomOutputType.definition,
+    [inputTypeId]: CustomInputType.export(),
+    [stringTypeId]: CustomStringType.export(),
+    [outputTypeId]: CustomOutputType.export(),
   });
 });
 
@@ -123,7 +123,7 @@ Deno.test("Manifest() automatically registers types referenced by datastores", (
   };
   const manifest = Manifest(definition);
   assertEquals(definition.types, [StringType]);
-  assertEquals(manifest.types, { [stringTypeId]: StringType.definition });
+  assertEquals(manifest.types, { [stringTypeId]: StringType.export() });
 });
 
 Deno.test("Manifest() automatically registers types referenced by other types", () => {
@@ -182,11 +182,11 @@ Deno.test("Manifest() automatically registers types referenced by other types", 
     BooleanType,
   ]);
   assertEquals(manifest.types, {
-    [arrayTypeId]: ArrayType.definition,
-    [customTypeId]: CustomType.definition,
-    // [objectTypeId]: ObjectType.definition,
-    [stringTypeId]: StringType.definition,
-    [booleanTypeId]: BooleanType.definition,
+    [arrayTypeId]: ArrayType.export(),
+    [customTypeId]: CustomType.export(),
+    // [objectTypeId]: ObjectType.export(),
+    [stringTypeId]: StringType.export(),
+    [booleanTypeId]: BooleanType.export(),
   });
 });
 
@@ -251,8 +251,8 @@ Deno.test("SlackManifest() registration functions don't allow duplicates", () =>
   assertEquals(exportedManifest.functions, { [functionId]: Func.export() });
   assertEquals(definition.types, [CustomArrayType, CustomStringType]);
   assertEquals(exportedManifest.types, {
-    [arrayTypeId]: CustomArrayType.definition,
-    [stringTypeId]: CustomStringType.definition,
+    [arrayTypeId]: CustomArrayType.export(),
+    [stringTypeId]: CustomStringType.export(),
   });
 });
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -51,4 +51,8 @@ export class CustomType<Def extends CustomTypeDefinition>
       manifest.registerType(this.definition.type);
     }
   }
+  export() {
+    const { callback_id: _c, ...definition } = this.definition;
+    return definition;
+  }
 }

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -52,6 +52,7 @@ export class CustomType<Def extends CustomTypeDefinition>
     }
   }
   export() {
+    // remove callback_id from the definition we pass to the manifest
     const { callback_id: _c, ...definition } = this.definition;
     return definition;
   }

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -1,4 +1,5 @@
 import { SlackManifest } from "../manifest.ts";
+import { ManifestCustomTypeSchema } from "../types.ts";
 import { CustomTypeDefinition, ICustomType } from "./types.ts";
 
 export const DefineType = <Def extends CustomTypeDefinition>(
@@ -51,7 +52,7 @@ export class CustomType<Def extends CustomTypeDefinition>
       manifest.registerType(this.definition.type);
     }
   }
-  export() {
+  export(): ManifestCustomTypeSchema {
     // remove callback_id from the definition we pass to the manifest
     const { callback_id: _c, ...definition } = this.definition;
     return definition;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,6 @@
 import { TypedParameterDefinition } from "../parameters/types.ts";
 import { SlackManifest } from "../manifest.ts";
+import { ManifestCustomTypeSchema } from "../types.ts";
 
 export type CustomTypeDefinition =
   & { callback_id: string }
@@ -10,4 +11,5 @@ export interface ICustomType {
   definition: CustomTypeDefinition;
   description?: string;
   registerParameterTypes: (manifest: SlackManifest) => void;
+  export(): ManifestCustomTypeSchema;
 }


### PR DESCRIPTION
# Summary
Make sure `callback_id` doesn't make it to the manifest

## Description
Right now if we try to use a type and deploy it, we'll get an error from the API endpoint that `callback_id` isn't a valid field for types. We need to make sure that `callback_id` is dropped before we export the manifest, which we now do by using an `export` method on the Custom Type.