### PR TITLE
Add type support for integer, number, usergroup, timestamp, and blocks

### DIFF
--- a/src/functions/functions_test.ts
+++ b/src/functions/functions_test.ts
@@ -35,7 +35,7 @@ Deno.test("Function with required params", () => {
           type: Schema.types.boolean,
           title: "My boolean",
         },
-        integer: {
+        myInteger: {
           type: Schema.types.integer,
           description: "integer",
         },

--- a/src/functions/functions_test.ts
+++ b/src/functions/functions_test.ts
@@ -35,16 +35,16 @@ Deno.test("Function with required params", () => {
           type: Schema.types.boolean,
           title: "My boolean",
         },
-        // integer: {
-        //   type: Schema.types.integer,
-        //   description: "integer",
-        // },
-        // myNumber: {
-        //   type: Schema.types.number,
-        //   description: "number",
-        // },
+        integer: {
+          type: Schema.types.integer,
+          description: "integer",
+        },
+        myNumber: {
+          type: Schema.types.number,
+          description: "number",
+        },
       },
-      required: ["myString" /* , "myNumber" */],
+      required: ["myString", "myNumber"],
     },
     output_parameters: {
       properties: {
@@ -58,7 +58,7 @@ Deno.test("Function with required params", () => {
 
   assertEquals(AllTypesFunction.definition.input_parameters?.required, [
     "myString",
-    // "myNumber",
+    "myNumber",
   ]);
   assertEquals(AllTypesFunction.definition.output_parameters?.required, [
     "out",

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -34,10 +34,10 @@ export type FunctionInvocationBody = {
  */
 type FunctionInputRuntimeType<Param extends ParameterDefinition> =
   Param["type"] extends typeof SchemaTypes.string ? string
-    : // : Param["type"] extends
-    //   | typeof SchemaTypes.integer
-    //   | typeof SchemaTypes.number ? number
-    Param["type"] extends typeof SchemaTypes.boolean ? boolean
+    : Param["type"] extends
+      | typeof SchemaTypes.integer
+      | typeof SchemaTypes.number ? number
+    : Param["type"] extends typeof SchemaTypes.boolean ? boolean
     : Param["type"] extends typeof SchemaTypes.array
       ? Param extends TypedArrayParameterDefinition
         ? TypedArrayFunctionInputRuntimeType<Param>
@@ -48,10 +48,10 @@ type FunctionInputRuntimeType<Param extends ParameterDefinition> =
     //   : UnknownRuntimeType
     Param["type"] extends
       | typeof SlackSchemaTypes.user_id
-      // | typeof SlackSchemaTypes.usergroup_id
+      | typeof SlackSchemaTypes.usergroup_id
       | typeof SlackSchemaTypes.channel_id ? string
-    : // : Param["type"] extends typeof SlackSchemaTypes.timestamp ? number
-    UnknownRuntimeType;
+    : Param["type"] extends typeof SlackSchemaTypes.timestamp ? number
+    : UnknownRuntimeType;
 
 // deno-lint-ignore no-explicit-any
 type UnknownRuntimeType = any;

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -4,8 +4,8 @@ import { ICustomType } from "../types/types.ts";
 export type PrimitiveParameterDefinition =
   | BooleanParameterDefinition
   | StringParameterDefinition
-  // | NumberParameterDefinition
-  // | IntegerParameterDefinition
+  | NumberParameterDefinition
+  | IntegerParameterDefinition
   | BaseParameterDefinition<AllValues>
   // | UntypedArrayParameterDefinition
   | TypedArrayParameterDefinition;
@@ -71,29 +71,29 @@ type StringParameterDefinition = BaseParameterDefinition<string> & {
   choices?: EnumChoice<string>[];
 };
 
-// type IntegerParameterDefinition = BaseParameterDefinition<number> & {
-//   type: typeof SchemaTypes.integer;
-//   /** Absolute minimum acceptable value for the integer */
-//   minimum?: number;
-//   /** Absolute maximum acceptable value for the integer */
-//   maximum?: number;
-//   /** Constrain the available integer options to just the list of integers denoted in the `enum` property. Usage of `enum` also instructs any UI that collects a value for this parameter to render a dropdown select input rather than a free-form text input. */
-//   enum?: number[];
-//   /** Defines labels that correspond to the `enum` values. */
-//   choices?: EnumChoice<number>[];
-// };
+type IntegerParameterDefinition = BaseParameterDefinition<number> & {
+  type: typeof SchemaTypes.integer;
+  /** Absolute minimum acceptable value for the integer */
+  minimum?: number;
+  /** Absolute maximum acceptable value for the integer */
+  maximum?: number;
+  /** Constrain the available integer options to just the list of integers denoted in the `enum` property. Usage of `enum` also instructs any UI that collects a value for this parameter to render a dropdown select input rather than a free-form text input. */
+  enum?: number[];
+  /** Defines labels that correspond to the `enum` values. */
+  choices?: EnumChoice<number>[];
+};
 
-// type NumberParameterDefinition = BaseParameterDefinition<number> & {
-//   type: typeof SchemaTypes.number;
-//   /** Absolute minimum acceptable value for the number */
-//   minimum?: number;
-//   /** Absolute maximum acceptable value for the number */
-//   maximum?: number;
-//   /** Constrain the available number options to just the list of numbers denoted in the `enum` property. Usage of `enum` also instructs any UI that collects a value for this parameter to render a dropdown select input rather than a free-form text input. */
-//   enum?: number[];
-//   /** Defines labels that correspond to the `enum` values. */
-//   choices?: EnumChoice<number>[];
-// };
+type NumberParameterDefinition = BaseParameterDefinition<number> & {
+  type: typeof SchemaTypes.number;
+  /** Absolute minimum acceptable value for the number */
+  minimum?: number;
+  /** Absolute maximum acceptable value for the number */
+  maximum?: number;
+  /** Constrain the available number options to just the list of numbers denoted in the `enum` property. Usage of `enum` also instructs any UI that collects a value for this parameter to render a dropdown select input rather than a free-form text input. */
+  enum?: number[];
+  /** Defines labels that correspond to the `enum` values. */
+  choices?: EnumChoice<number>[];
+};
 
 type EnumChoice<T> = {
   /** The `enum` value this {@link EnumChoice} corresponds to. */

--- a/src/schema/schema_types.ts
+++ b/src/schema/schema_types.ts
@@ -1,8 +1,8 @@
 const SchemaTypes = {
   string: "string",
   boolean: "boolean",
-  // integer: "integer",
-  // number: "number",
+  integer: "integer",
+  number: "number",
   // object: "object",
   array: "array",
 } as const;

--- a/src/schema/slack/schema_types.ts
+++ b/src/schema/slack/schema_types.ts
@@ -1,9 +1,9 @@
 const SlackTypes = {
   user_id: "slack#/types/user_id",
   channel_id: "slack#/types/channel_id",
-  // usergroup_id: "slack#/types/usergroup_id",
-  // timestamp: "slack#/types/timestamp",
-  // blocks: "slack#/types/blocks",
+  usergroup_id: "slack#/types/usergroup_id",
+  timestamp: "slack#/types/timestamp",
+  blocks: "slack#/types/blocks",
 } as const;
 
 export default SlackTypes;


### PR DESCRIPTION
### Summary

Add type support for `integer`, `number`, `usergroup_id`, `timestamp`, and `blocks`

#### Details
Reintroducing support for types that aren't supported by input fields.

#### Testing
I'd recommend doing this somewhere with auto-generated shortcuts still enabled for every function, and then using these various types.