### PR TITLE
Adding support for the Object type again

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -8,13 +8,30 @@ Types can be defined with the top level `DefineType` export. Below is an example
 of setting up a custom Type used for setting shared boundaries on strings.
 
 ```ts
-const LimitedStringType = DefineType({
-  callback_id: "limited_string",
-  title: "String with length restrictions",
-  description: "Use this to provide boundaries to your string",
-  type: Schema.types.string,
-  minLength: 3,
-  maxLength: 8
+const IncidentType = DefineType({
+  callback_id: "incident",
+  title: "Incident Ticket",
+  description: "Use this to enter an Incident Ticket",
+  type: Schema.types.object,
+  properties: {
+    id: {
+      type: Schema.types.string,
+      minLength: 3,
+    },
+    title: {
+      type: Schema.types.string,
+    },
+    summary: {
+      type: Schema.types.string,
+    },
+    severity: {
+      type: Schema.types.string,
+    },
+    date_created: {
+      type: Schema.types.number,
+    },
+  },
+  required: [],
 }
 ```
 
@@ -25,7 +42,7 @@ parameter while defining the [`Manifest`][manifest].
 
 Note: All Custom Types **must** be registered to the [Manifest][manifest] in
 order for them to be used, but any types referenced by existing
-[`functions`][functions], [`datastores`][datastores], or other types will be
+[`functions`][functions], [`workflows`][workflows], [`datastores`][datastores], or other types will be
 registered automatically.
 
 ```ts
@@ -42,9 +59,9 @@ property to the Type it should reference.
 
 ```js
 input_parameters: {
-  secret: : {
-    title: 'A Special String',
-    type: LimitedStringType
+  incident: : {
+    title: 'A Special Incident',
+    type: IncidentType
   }
    ...
 }
@@ -55,3 +72,4 @@ _In the provided example the title from the Custom Type is being overridden_
 [functions]: ./functions.md
 [manifest]: ./manifest.md
 [datastores]: ./datastores.md
+[workflows]: ./workflows.md

--- a/src/datastore/datastore_test.ts
+++ b/src/datastore/datastore_test.ts
@@ -22,6 +22,12 @@ Deno.test("Datastore sets appropriate defaults", () => {
       attr3: {
         type: customType,
       },
+      attr4: {
+        type: SchemaTypes.object,
+        properties: {
+          anObjectString: { type: SchemaTypes.string },
+        },
+      },
     },
   });
 
@@ -30,4 +36,9 @@ Deno.test("Datastore sets appropriate defaults", () => {
   assertStrictEquals(exported.attributes.attr1.type, SchemaTypes.string);
   assertStrictEquals(exported.attributes.attr2.type, SchemaTypes.boolean);
   assertStrictEquals(exported.attributes.attr3.type, customType);
+  assertStrictEquals(exported.attributes.attr4.type, SchemaTypes.object);
+  assertStrictEquals(
+    exported.attributes.attr4.properties?.anObjectString?.type,
+    SchemaTypes.string,
+  );
 });

--- a/src/functions/base_function_handler_type_test.ts
+++ b/src/functions/base_function_handler_type_test.ts
@@ -27,7 +27,7 @@ Deno.test("BaseSlackFunctionHandler types", () => {
   assertEquals(result.outputs?.out, inputs.in);
 });
 
-Deno.test("BaseSlackFunctionHandler with empty inputs and outputs", () => {
+Deno.test("BaseSlackFunctionHandler with empty inputs and empty outputs", () => {
   type Inputs = Record<never, never>;
   type Outputs = Record<never, never>;
   const handler: BaseSlackFunctionHandler<Inputs, Outputs> = () => {
@@ -143,4 +143,28 @@ Deno.test("BaseSlackFunctionHandler with set inputs and any outputs", () => {
   const inputs = { in: "test" };
   const result = handler(createContext({ inputs }));
   assertEquals(result.outputs?.out, inputs.in);
+});
+
+Deno.test("BaseSlackFunctionHandler with input and output objects", () => {
+  type Inputs = {
+    anObject: {
+      in: string;
+    };
+  };
+  type Outputs = {
+    anObject: {
+      out: string;
+    };
+  };
+  const handler: BaseSlackFunctionHandler<Inputs, Outputs> = ({ inputs }) => {
+    return {
+      outputs: {
+        anObject: { out: inputs.anObject.in },
+      },
+    };
+  };
+  const { createContext } = SlackFunctionTester("test");
+  const inputs = { anObject: { in: "test" } };
+  const result = handler(createContext({ inputs }));
+  assertEquals(result.outputs?.anObject?.out, inputs.anObject.in);
 });

--- a/src/functions/slack_function_handler_type_test.ts
+++ b/src/functions/slack_function_handler_type_test.ts
@@ -191,6 +191,50 @@ Deno.test("SlackFunctionHandler with only outputs", () => {
   assertEquals(result.outputs?.out, "test");
 });
 
+Deno.test("SlackFunctionHandler with input and output object", () => {
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+    input_parameters: {
+      properties: {
+        anObject: {
+          type: "object",
+          properties: { in: { type: "string" } },
+          required: ["in"],
+        },
+      },
+      required: ["anObject"],
+    },
+    output_parameters: {
+      properties: {
+        anObject: {
+          type: "object",
+          properties: { out: { type: "string" } },
+          required: ["out"],
+        },
+      },
+      required: ["anObject"],
+    },
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = (
+    { inputs },
+  ) => {
+    return {
+      outputs: {
+        anObject: {
+          out: inputs.anObject.in,
+        },
+      },
+    };
+  };
+  const { createContext } = SlackFunctionTester(TestFn);
+  const result = handler(
+    createContext({ inputs: { anObject: { in: "test" } } }),
+  );
+  assertEquals(result.outputs?.anObject.out, "test");
+});
+
 Deno.test("SlackFunctionHandler with only completed false", () => {
   const TestFn = DefineFunction({
     callback_id: "test",

--- a/src/functions/slack_function_handler_type_test.ts
+++ b/src/functions/slack_function_handler_type_test.ts
@@ -1,8 +1,7 @@
-import { assertEquals, assertExists } from "../dev_deps.ts";
+import { assertEquals } from "../dev_deps.ts";
 import { SlackFunctionTester } from "./tester/mod.ts";
 import { DefineFunction } from "./mod.ts";
 import { SlackFunctionHandler } from "./types.ts";
-import { DefineType } from "../mod.ts";
 
 // These tests are to ensure our Function Handler types are supporting the use cases we want to
 // Any "failures" here will most likely be reflected in Type errors
@@ -234,60 +233,6 @@ Deno.test("SlackFunctionHandler with input and output object", () => {
     createContext({ inputs: { anObject: { in: "test" } } }),
   );
   assertEquals(result.outputs?.anObject.out, "test");
-});
-
-Deno.test("SlackFunctionHandler with custom type inputs", () => {
-  const TestStringType = DefineType({
-    callback_id: "example_string",
-    type: "string",
-  });
-  const TestObjectType = DefineType({
-    callback_id: "example_object",
-    type: "object",
-    properties: {
-      in: { type: TestStringType },
-    },
-  });
-  const TestFn = DefineFunction({
-    callback_id: "test",
-    title: "test fn",
-    source_file: "test.ts",
-    input_parameters: {
-      properties: {
-        anObject: {
-          type: TestObjectType,
-        },
-        aString: {
-          type: TestStringType,
-        },
-      },
-      required: ["anObject", "aString"],
-    },
-    output_parameters: {
-      properties: {
-        out: { type: "string" },
-      },
-      required: ["out"],
-    },
-  });
-  const handler: SlackFunctionHandler<typeof TestFn.definition> = (
-    { inputs },
-  ) => {
-    assertExists(inputs.anObject.in);
-    assertExists(inputs.aString);
-    return {
-      outputs: {
-        out: inputs.anObject.in || inputs.aString,
-      },
-    };
-  };
-  const { createContext } = SlackFunctionTester(TestFn);
-  const result = handler(
-    createContext({
-      inputs: { anObject: { in: "type_test" }, aString: "another_type_test" },
-    }),
-  );
-  assertEquals(result.outputs?.out, "type_test");
 });
 
 Deno.test("SlackFunctionHandler with only completed false", () => {

--- a/src/functions/slack_function_handler_type_test.ts
+++ b/src/functions/slack_function_handler_type_test.ts
@@ -1,7 +1,8 @@
-import { assertEquals } from "../dev_deps.ts";
+import { assertEquals, assertExists } from "../dev_deps.ts";
 import { SlackFunctionTester } from "./tester/mod.ts";
 import { DefineFunction } from "./mod.ts";
 import { SlackFunctionHandler } from "./types.ts";
+import { DefineType } from "../mod.ts";
 
 // These tests are to ensure our Function Handler types are supporting the use cases we want to
 // Any "failures" here will most likely be reflected in Type errors
@@ -233,6 +234,60 @@ Deno.test("SlackFunctionHandler with input and output object", () => {
     createContext({ inputs: { anObject: { in: "test" } } }),
   );
   assertEquals(result.outputs?.anObject.out, "test");
+});
+
+Deno.test("SlackFunctionHandler with custom type inputs", () => {
+  const TestStringType = DefineType({
+    callback_id: "example_string",
+    type: "string",
+  });
+  const TestObjectType = DefineType({
+    callback_id: "example_object",
+    type: "object",
+    properties: {
+      in: { type: TestStringType },
+    },
+  });
+  const TestFn = DefineFunction({
+    callback_id: "test",
+    title: "test fn",
+    source_file: "test.ts",
+    input_parameters: {
+      properties: {
+        anObject: {
+          type: TestObjectType,
+        },
+        aString: {
+          type: TestStringType,
+        },
+      },
+      required: ["anObject", "aString"],
+    },
+    output_parameters: {
+      properties: {
+        out: { type: "string" },
+      },
+      required: ["out"],
+    },
+  });
+  const handler: SlackFunctionHandler<typeof TestFn.definition> = (
+    { inputs },
+  ) => {
+    assertExists(inputs.anObject.in);
+    assertExists(inputs.aString);
+    return {
+      outputs: {
+        out: inputs.anObject.in || inputs.aString,
+      },
+    };
+  };
+  const { createContext } = SlackFunctionTester(TestFn);
+  const result = handler(
+    createContext({
+      inputs: { anObject: { in: "type_test" }, aString: "another_type_test" },
+    }),
+  );
+  assertEquals(result.outputs?.out, "type_test");
 });
 
 Deno.test("SlackFunctionHandler with only completed false", () => {

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -12,6 +12,7 @@ import {
 import type SchemaTypes from "../schema/schema_types.ts";
 import type SlackSchemaTypes from "../schema/slack/schema_types.ts";
 import { SlackManifest } from "../manifest.ts";
+import { ICustomType } from "../types/types.ts";
 
 export type FunctionInvocationBody = {
   "team_id": string;
@@ -36,7 +37,11 @@ export type FunctionInvocationBody = {
  * @description Maps a ParameterDefinition into a runtime type, i.e. "string" === string.
  */
 type FunctionInputRuntimeType<Param extends ParameterDefinition> =
-  Param["type"] extends typeof SchemaTypes.string ? string
+  Param["type"] extends ICustomType
+    // If the Parameter is a Custom Type, use the type's definition
+    ? FunctionInputRuntimeType<Param["type"]["definition"]>
+    // Otherwise, use the type itself
+    : Param["type"] extends typeof SchemaTypes.string ? string
     : Param["type"] extends
       | typeof SchemaTypes.integer
       | typeof SchemaTypes.number ? number

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -5,7 +5,10 @@ import {
   ParameterSetDefinition,
   PossibleParameterKeys,
 } from "../parameters/mod.ts";
-import { TypedArrayParameterDefinition } from "../parameters/types.ts";
+import {
+  TypedArrayParameterDefinition,
+  TypedObjectParameterDefinition,
+} from "../parameters/types.ts";
 import type SchemaTypes from "../schema/schema_types.ts";
 import type SlackSchemaTypes from "../schema/slack/schema_types.ts";
 import { SlackManifest } from "../manifest.ts";
@@ -42,11 +45,11 @@ type FunctionInputRuntimeType<Param extends ParameterDefinition> =
       ? Param extends TypedArrayParameterDefinition
         ? TypedArrayFunctionInputRuntimeType<Param>
       : UnknownRuntimeType[]
-    : // : Param["type"] extends typeof SchemaTypes.object
-    //   ? Param extends TypedObjectParameterDefinition
-    //     ? TypedObjectFunctionInputRuntimeType<Param>
-    //   : UnknownRuntimeType
-    Param["type"] extends
+    : Param["type"] extends typeof SchemaTypes.object
+      ? Param extends TypedObjectParameterDefinition
+        ? TypedObjectFunctionInputRuntimeType<Param>
+      : UnknownRuntimeType
+    : Param["type"] extends
       | typeof SlackSchemaTypes.user_id
       | typeof SlackSchemaTypes.usergroup_id
       | typeof SlackSchemaTypes.channel_id ? string
@@ -55,6 +58,18 @@ type FunctionInputRuntimeType<Param extends ParameterDefinition> =
 
 // deno-lint-ignore no-explicit-any
 type UnknownRuntimeType = any;
+
+type TypedObjectFunctionInputRuntimeType<
+  Param extends TypedObjectParameterDefinition,
+> =
+  & {
+    [k in keyof Param["properties"]]: FunctionInputRuntimeType<
+      Param["properties"][k]
+    >;
+  }
+  & {
+    [key: string]: UnknownRuntimeType;
+  };
 
 type TypedArrayFunctionInputRuntimeType<
   Param extends TypedArrayParameterDefinition,

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -12,7 +12,6 @@ import {
 import type SchemaTypes from "../schema/schema_types.ts";
 import type SlackSchemaTypes from "../schema/slack/schema_types.ts";
 import { SlackManifest } from "../manifest.ts";
-import { ICustomType } from "../types/types.ts";
 
 export type FunctionInvocationBody = {
   "team_id": string;
@@ -37,11 +36,7 @@ export type FunctionInvocationBody = {
  * @description Maps a ParameterDefinition into a runtime type, i.e. "string" === string.
  */
 type FunctionInputRuntimeType<Param extends ParameterDefinition> =
-  Param["type"] extends ICustomType
-    // If the Parameter is a Custom Type, use the type's definition
-    ? FunctionInputRuntimeType<Param["type"]["definition"]>
-    // Otherwise, use the type itself
-    : Param["type"] extends typeof SchemaTypes.string ? string
+  Param["type"] extends typeof SchemaTypes.string ? string
     : Param["type"] extends
       | typeof SchemaTypes.integer
       | typeof SchemaTypes.number ? number

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -1,12 +1,13 @@
 // import SchemaTypes from "../schema/schema_types.ts";
 import type {
   CustomTypeParameterDefinition,
-  // TypedObjectParameterDefinition,
+  TypedObjectParameterDefinition,
   TypedParameterDefinition,
-  // UntypedObjectParameterDefinition,
+  UntypedObjectParameterDefinition,
 } from "./types.ts";
 import { ParamReference } from "./param.ts";
 import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
+import SchemaTypes from "../schema/schema_types.ts";
 
 export type ParameterDefinition = TypedParameterDefinition;
 
@@ -30,11 +31,11 @@ export type ParameterPropertiesDefinition<
 export type ParameterVariableType<Def extends ParameterDefinition> = Def extends
   CustomTypeParameterDefinition // If the ParameterVariable is a Custom type, use it's definition instead
   ? ParameterVariableType<Def["type"]["definition"]>
-  : // : Def extends TypedObjectParameterDefinition // If the ParameterVariable is of type object, allow access to the object's properties
-  //   ? ObjectParameterVariableType<Def>
-  // : Def extends UntypedObjectParameterDefinition
-  //   ? UntypedObjectParameterVariableType
-  SingleParameterVariable;
+  : Def extends TypedObjectParameterDefinition // If the ParameterVariable is of type object, allow access to the object's properties
+    ? ObjectParameterVariableType<Def>
+  : Def extends UntypedObjectParameterDefinition
+    ? UntypedObjectParameterVariableType
+  : SingleParameterVariable;
 
 // deno-lint-ignore ban-types
 type SingleParameterVariable = {};
@@ -42,23 +43,23 @@ type SingleParameterVariable = {};
 // deno-lint-ignore no-explicit-any
 type UntypedObjectParameterVariableType = any;
 
-// type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
-//   {
-//     [name in keyof Def["properties"]]: ParameterVariableType<
-//       Def["properties"][name]
-//     >;
-//   };
+type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
+  {
+    [name in keyof Def["properties"]]: ParameterVariableType<
+      Def["properties"][name]
+    >;
+  };
 
 // If additionalProperties is set to true, allow access to any key
 // Otherwise, only allow keys provided through use of properties
-// type ObjectParameterVariableType<Def extends TypedObjectParameterDefinition> =
-//   Def["additionalProperties"] extends true ?
-//     & ObjectParameterPropertyTypes<Def>
-//     & {
-//       // deno-lint-ignore no-explicit-any
-//       [key: string]: any;
-//     }
-//     : ObjectParameterPropertyTypes<Def>;
+type ObjectParameterVariableType<Def extends TypedObjectParameterDefinition> =
+  Def["additionalProperties"] extends true ? 
+    & ObjectParameterPropertyTypes<Def>
+    & {
+      // deno-lint-ignore no-explicit-any
+      [key: string]: any;
+    }
+    : ObjectParameterPropertyTypes<Def>;
 
 export const ParameterVariable = <P extends ParameterDefinition>(
   namespace: string,
@@ -74,16 +75,16 @@ export const ParameterVariable = <P extends ParameterDefinition>(
       paramName,
       definition.type.definition,
     ) as ParameterVariableType<P>;
-    // } else if (definition.type === SchemaTypes.object) {
-    //   if ("properties" in definition) {
-    //     param = CreateTypedObjectParameterVariable(
-    //       namespace,
-    //       paramName,
-    //       definition,
-    //     ) as ParameterVariableType<P>;
-    //   } else {
-    //     param = CreateUntypedObjectParameterVariable(namespace, paramName);
-    //   }
+  } else if (definition.type === SchemaTypes.object) {
+    if ("properties" in definition) {
+      param = CreateTypedObjectParameterVariable(
+        namespace,
+        paramName,
+        definition,
+      ) as ParameterVariableType<P>;
+    } else {
+      param = CreateUntypedObjectParameterVariable(namespace, paramName);
+    }
   } else {
     param = CreateSingleParameterVariable(
       namespace,
@@ -94,36 +95,36 @@ export const ParameterVariable = <P extends ParameterDefinition>(
   return param as ParameterVariableType<P>;
 };
 
-// const CreateTypedObjectParameterVariable = <
-//   P extends TypedObjectParameterDefinition,
-// >(
-//   namespace: string,
-//   paramName: string,
-//   definition: P,
-// ): ObjectParameterVariableType<P> => {
-//   const ns = namespace ? `${namespace}.` : "";
-//   const pathReference = `${ns}${paramName}`;
-//   const param = ParamReference(pathReference);
+const CreateTypedObjectParameterVariable = <
+  P extends TypedObjectParameterDefinition,
+>(
+  namespace: string,
+  paramName: string,
+  definition: P,
+): ObjectParameterVariableType<P> => {
+  const ns = namespace ? `${namespace}.` : "";
+  const pathReference = `${ns}${paramName}`;
+  const param = ParamReference(pathReference);
 
-//   for (
-//     const [propName, propDefinition] of Object.entries(
-//       definition.properties || {},
-//     )
-//   ) {
-//     param[propName as string] = ParameterVariable(
-//       pathReference,
-//       propName,
-//       propDefinition,
-//     );
-//   }
+  for (
+    const [propName, propDefinition] of Object.entries(
+      definition.properties || {},
+    )
+  ) {
+    param[propName as string] = ParameterVariable(
+      pathReference,
+      propName,
+      propDefinition,
+    );
+  }
 
-//   // We wrap the typed object parameter w/ an untyped proxy to allow indexing into additional properties
-//   return WithUntypedObjectProxy(
-//     param,
-//     namespace,
-//     paramName,
-//   ) as ObjectParameterVariableType<P>;
-// };
+  // We wrap the typed object parameter w/ an untyped proxy to allow indexing into additional properties
+  return WithUntypedObjectProxy(
+    param,
+    namespace,
+    paramName,
+  ) as ObjectParameterVariableType<P>;
+};
 
 export const CreateUntypedObjectParameterVariable = (
   namespace: string,

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -50,8 +50,7 @@ type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
     >;
   };
 
-// If additionalProperties is set to true, allow access to any key
-// Otherwise, only allow keys provided through use of properties
+// If additionalProperties is set to true, allow access to any key. Otherwise, only allow keys provided through use of properties
 type ObjectParameterVariableType<Def extends TypedObjectParameterDefinition> =
   Def["additionalProperties"] extends true ? 
     & ObjectParameterPropertyTypes<Def>

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -50,14 +50,15 @@ type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
     >;
   };
 
-// If additionalProperties is set to true, allow access to any key. Otherwise, only allow keys provided through use of properties
+// If additionalProperties is set to true, allow access to any key.
+// Otherwise, only allow keys provided through use of properties
 type ObjectParameterVariableType<Def extends TypedObjectParameterDefinition> =
   Def["additionalProperties"] extends true ? 
-    & ObjectParameterPropertyTypes<Def>
-    & {
-      // deno-lint-ignore no-explicit-any
-      [key: string]: any;
-    }
+      & ObjectParameterPropertyTypes<Def>
+      & {
+        // deno-lint-ignore no-explicit-any
+        [key: string]: any;
+      }
     : ObjectParameterPropertyTypes<Def>;
 
 export const ParameterVariable = <P extends ParameterDefinition>(

--- a/src/parameters/parameter-variable_test.ts
+++ b/src/parameters/parameter-variable_test.ts
@@ -11,54 +11,54 @@ Deno.test("ParameterVariable string", () => {
   assertStrictEquals(`${param}`, "{{incident_name}}");
 });
 
-// Deno.test("ParameterVariable typed object", () => {
-//   const param = ParameterVariable("", "incident", {
-//     type: SchemaTypes.object,
-//     properties: {
-//       id: {
-//         type: SchemaTypes.integer,
-//       },
-//       name: {
-//         type: SchemaTypes.string,
-//       },
-//     },
-//   });
+Deno.test("ParameterVariable typed object", () => {
+  const param = ParameterVariable("", "incident", {
+    type: SchemaTypes.object,
+    properties: {
+      id: {
+        type: SchemaTypes.integer,
+      },
+      name: {
+        type: SchemaTypes.string,
+      },
+    },
+  });
 
-//   assertEquals(`${param}`, "{{incident}}");
-//   assertEquals(`${param.id}`, "{{incident.id}}");
-//   assertEquals(`${param.name}`, "{{incident.name}}");
-// });
+  assertStrictEquals(`${param}`, "{{incident}}");
+  assertStrictEquals(`${param.id}`, "{{incident.id}}");
+  assertStrictEquals(`${param.name}`, "{{incident.name}}");
+});
 
-// Deno.test("ParameterVariable typed object with additional properties", () => {
-//   const param = ParameterVariable("", "incident", {
-//     type: SchemaTypes.object,
-//     properties: {
-//       id: {
-//         type: SchemaTypes.integer,
-//       },
-//       name: {
-//         type: SchemaTypes.string,
-//       },
-//     },
-//     additionalProperties: true,
-//   });
+Deno.test("ParameterVariable typed object with additional properties", () => {
+  const param = ParameterVariable("", "incident", {
+    type: SchemaTypes.object,
+    properties: {
+      id: {
+        type: SchemaTypes.integer,
+      },
+      name: {
+        type: SchemaTypes.string,
+      },
+    },
+    additionalProperties: true,
+  });
 
-//   assertEquals(`${param}`, "{{incident}}");
-//   assertEquals(`${param.id}`, "{{incident.id}}");
-//   assertEquals(`${param.name}`, "{{incident.name}}");
-//   assertEquals(`${param.foo.bar}`, "{{incident.foo.bar}}");
-// });
+  assertStrictEquals(`${param}`, "{{incident}}");
+  assertStrictEquals(`${param.id}`, "{{incident.id}}");
+  assertStrictEquals(`${param.name}`, "{{incident.name}}");
+  assertStrictEquals(`${param.foo.bar}`, "{{incident.foo.bar}}");
+});
 
-// Deno.test("ParameterVariable untyped object", () => {
-//   const param = ParameterVariable("", "incident", {
-//     type: SchemaTypes.object,
-//   });
+Deno.test("ParameterVariable untyped object", () => {
+  const param = ParameterVariable("", "incident", {
+    type: SchemaTypes.object,
+  });
 
-//   assertEquals(`${param}`, "{{incident}}");
-//   assertEquals(`${param.id}`, "{{incident.id}}");
-//   assertEquals(`${param.name}`, "{{incident.name}}");
-//   assertEquals(`${param.name.foo.bar}`, "{{incident.name.foo.bar}}");
-// });
+  assertStrictEquals(`${param}`, "{{incident}}");
+  assertStrictEquals(`${param.id}`, "{{incident.id}}");
+  assertStrictEquals(`${param.name}`, "{{incident.name}}");
+  assertStrictEquals(`${param.name.foo.bar}`, "{{incident.name.foo.bar}}");
+});
 
 Deno.test("ParameterVariable array of strings", () => {
   const param = ParameterVariable("", "myArray", {
@@ -83,38 +83,41 @@ Deno.test("ParameterVariable using CustomType string", () => {
   assertStrictEquals(`${param}`, "{{myCustomTypeString}}");
 });
 
-// Deno.test("ParameterVariable using Custom Type typed object", () => {
-//   const customType = DefineType({
-//     callback_id: "customType",
-//     type: SchemaTypes.object,
-//     properties: {
-//       aString: {
-//         type: SchemaTypes.string,
-//       },
-//     },
-//   });
-//   const param = ParameterVariable("", "myCustomType", {
-//     type: customType,
-//   });
+Deno.test("ParameterVariable using Custom Type typed object", () => {
+  const customType = DefineType({
+    callback_id: "customType",
+    type: SchemaTypes.object,
+    properties: {
+      aString: {
+        type: SchemaTypes.string,
+      },
+    },
+  });
+  const param = ParameterVariable("", "myCustomType", {
+    type: customType,
+  });
 
-//   assertEquals(`${param}`, "{{myCustomType}}");
-//   assertEquals(`${param.aString}`, "{{myCustomType.aString}}");
-// });
+  assertStrictEquals(`${param}`, "{{myCustomType}}");
+  assertStrictEquals(`${param.aString}`, "{{myCustomType.aString}}");
+});
 
-// Deno.test("ParameterVariable using Custom Type untyped object", () => {
-//   const customType = DefineType({
-//     callback_id: "customTypeObject",
-//     type: SchemaTypes.object,
-//   });
-//   const param = ParameterVariable("", "myCustomTypeObject", {
-//     type: customType,
-//   });
+Deno.test("ParameterVariable using Custom Type untyped object", () => {
+  const customType = DefineType({
+    callback_id: "customTypeObject",
+    type: SchemaTypes.object,
+  });
+  const param = ParameterVariable("", "myCustomTypeObject", {
+    type: customType,
+  });
 
-//   assertEquals(`${param}`, "{{myCustomTypeObject}}");
-//   assertEquals(`${param.foo}`, "{{myCustomTypeObject.foo}}");
-//   assertEquals(`${param.foo.bar}`, "{{myCustomTypeObject.foo.bar}}");
-//   assertEquals(`${param.foo.bar.baz}`, "{{myCustomTypeObject.foo.bar.baz}}");
-// });
+  assertStrictEquals(`${param}`, "{{myCustomTypeObject}}");
+  assertStrictEquals(`${param.foo}`, "{{myCustomTypeObject.foo}}");
+  assertStrictEquals(`${param.foo.bar}`, "{{myCustomTypeObject.foo.bar}}");
+  assertStrictEquals(
+    `${param.foo.bar.baz}`,
+    "{{myCustomTypeObject.foo.bar.baz}}",
+  );
+});
 
 Deno.test("ParameterVariable using Custom Type array", () => {
   const customType = DefineType({
@@ -128,45 +131,48 @@ Deno.test("ParameterVariable using Custom Type array", () => {
   assertStrictEquals(`${param}`, "{{myCustomTypeArray}}");
 });
 
-// Deno.test("ParameterVariable using Custom Type object referencing another Custom Type", () => {
-//   const StringType = DefineType({
-//     callback_id: "stringType",
-//     type: SchemaTypes.string,
-//     minLength: 2,
-//   });
-//   const customType = DefineType({
-//     callback_id: "customTypeWithCustomType",
-//     type: SchemaTypes.object,
-//     properties: {
-//       customType: {
-//         type: StringType,
-//       },
-//     },
-//   });
-//   const param = ParameterVariable("", "myNestedCustomType", {
-//     type: customType,
-//   });
+Deno.test("ParameterVariable using Custom Type object referencing another Custom Type", () => {
+  const StringType = DefineType({
+    callback_id: "stringType",
+    type: SchemaTypes.string,
+    minLength: 2,
+  });
+  const customType = DefineType({
+    callback_id: "customTypeWithCustomType",
+    type: SchemaTypes.object,
+    properties: {
+      customType: {
+        type: StringType,
+      },
+    },
+  });
+  const param = ParameterVariable("", "myNestedCustomType", {
+    type: customType,
+  });
 
-//   assertEquals(`${param}`, "{{myNestedCustomType}}");
-//   assertEquals(`${param.customType}`, "{{myNestedCustomType.customType}}");
-// });
+  assertStrictEquals(`${param}`, "{{myNestedCustomType}}");
+  assertStrictEquals(
+    `${param.customType}`,
+    "{{myNestedCustomType.customType}}",
+  );
+});
 
-// Deno.test("ParameterVariable typed object with Custom Type property", () => {
-//   const StringType = DefineType({
-//     callback_id: "stringType",
-//     type: SchemaTypes.string,
-//     minLength: 2,
-//   });
+Deno.test("ParameterVariable typed object with Custom Type property", () => {
+  const StringType = DefineType({
+    callback_id: "stringType",
+    type: SchemaTypes.string,
+    minLength: 2,
+  });
 
-//   const param = ParameterVariable("", "myObjectParam", {
-//     type: SchemaTypes.object,
-//     properties: {
-//       aString: {
-//         type: StringType,
-//       },
-//     },
-//   });
+  const param = ParameterVariable("", "myObjectParam", {
+    type: SchemaTypes.object,
+    properties: {
+      aString: {
+        type: StringType,
+      },
+    },
+  });
 
-//   assertEquals(`${param}`, "{{myObjectParam}}");
-//   assertEquals(`${param.aString}`, "{{myObjectParam.aString}}");
-// });
+  assertStrictEquals(`${param}`, "{{myObjectParam}}");
+  assertStrictEquals(`${param.aString}`, "{{myObjectParam.aString}}");
+});

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -11,9 +11,9 @@ export type PrimitiveParameterDefinition =
   | TypedArrayParameterDefinition;
 
 export type TypedParameterDefinition =
-  // | TypedObjectParameterDefinition
-  // | UntypedObjectParameterDefinition
-  PrimitiveParameterDefinition;
+  | TypedObjectParameterDefinition
+  | UntypedObjectParameterDefinition
+  | PrimitiveParameterDefinition;
 
 export type CustomTypeParameterDefinition =
   & BaseParameterDefinition<AllValues>
@@ -35,25 +35,25 @@ type BaseParameterDefinition<T> = {
   examples?: T[];
 };
 
-// export type UntypedObjectParameterDefinition =
-//   & BaseParameterDefinition<ObjectValue>
-//   & {
-//     type: typeof SchemaTypes.object;
-//   };
+export type UntypedObjectParameterDefinition =
+  & BaseParameterDefinition<ObjectValue>
+  & {
+    type: typeof SchemaTypes.object;
+  };
 
 // TODO: Required field should be limited to the names(key) of each property
-// export type TypedObjectParameterDefinition =
-//   & UntypedObjectParameterDefinition
-//   & {
-//     /** A list of required property names (must reference names defined on the `properties` property). Only for use with Object types. */
-//     required?: string[];
-//     /** Whether the parameter can accept objects with additional keys beyond those defined via `properties` */
-//     additionalProperties?: boolean;
-//     /** Object defining what properties are allowed on the parameter. */
-//     properties: {
-//       [key: string]: PrimitiveParameterDefinition;
-//     };
-// };
+export type TypedObjectParameterDefinition =
+  & UntypedObjectParameterDefinition
+  & {
+    /** A list of required property names (must reference names defined on the `properties` property). Only for use with Object types. */
+    required?: string[];
+    /** Whether the parameter can accept objects with additional keys beyond those defined via `properties` */
+    additionalProperties?: boolean;
+    /** Object defining what properties are allowed on the parameter. */
+    properties: {
+      [key: string]: PrimitiveParameterDefinition;
+    };
+  };
 
 type BooleanParameterDefinition = BaseParameterDefinition<boolean> & {
   type: typeof SchemaTypes.boolean;

--- a/src/schema/schema_types.ts
+++ b/src/schema/schema_types.ts
@@ -3,7 +3,7 @@ const SchemaTypes = {
   boolean: "boolean",
   integer: "integer",
   number: "number",
-  // object: "object",
+  object: "object",
   array: "array",
 } as const;
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -40,13 +40,13 @@ export class CustomType<Def extends CustomTypeDefinition>
       if (this.definition.items.type instanceof Object) {
         manifest.registerType(this.definition.items.type);
       }
-      // } else if ("properties" in this.definition) {
-      //   // Loop through the properties and register any types
-      //   Object.values(this.definition.properties)?.forEach((property) => {
-      //     if ("type" in property && property.type instanceof Object) {
-      //       manifest.registerType(property.type);
-      //     }
-      //   });
+    } else if ("properties" in this.definition) {
+      // Loop through the properties and register any types
+      Object.values(this.definition.properties)?.forEach((property) => {
+        if ("type" in property && property.type instanceof Object) {
+          manifest.registerType(property.type);
+        }
+      });
     } else if (this.definition.type instanceof Object) {
       // The referenced type is a Custom Type
       manifest.registerType(this.definition.type);

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -15,6 +15,13 @@ Deno.test("WorkflowStep export input values", () => {
         name: {
           type: "string",
         },
+        manager: {
+          type: "object",
+          properties: {
+            email: { type: "string" },
+            name: { type: "string" },
+          },
+        },
       },
       required: ["email"],
     },
@@ -39,8 +46,15 @@ Deno.test("WorkflowStep export input values", () => {
         name: {
           type: "string",
         },
+        manager: {
+          type: "object",
+          properties: {
+            email: { type: "string" },
+            name: { type: "string" },
+          },
+        },
       },
-      required: ["email"],
+      required: ["email", "manager"],
     },
   });
 
@@ -48,6 +62,10 @@ Deno.test("WorkflowStep export input values", () => {
   const step1 = workflow.addStep(TestFunction, {
     email: workflow.inputs.email,
     name: `A name: ${workflow.inputs.name}`,
+    manager: {
+      name: workflow.inputs.manager.name,
+      email: workflow.inputs.manager.email,
+    },
   });
 
   // add a manually configured step

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -30,6 +30,13 @@ Deno.test("WorkflowStep export input values", () => {
         url: {
           type: "string",
         },
+        manager: {
+          type: "object",
+          properties: {
+            email: { type: "string" },
+            name: { type: "string" },
+          },
+        },
       },
       required: ["url"],
     },
@@ -92,6 +99,8 @@ Deno.test("WorkflowStep export input values", () => {
   assertEquals(`${step1Inputs.email}`, "{{inputs.email}}");
   assertEquals(`${step1Inputs.name}`, "A name: {{inputs.name}}");
   assertEquals(`${step1.outputs.url}`, "{{steps.0.url}}");
+  assertEquals(`${step1.outputs.manager?.email}`, "{{steps.0.manager.email}}");
+  assertEquals(`${step1.outputs.manager?.name}`, "{{steps.0.manager.name}}");
 
   assertEquals(
     `${step2Inputs.channel_name}`,


### PR DESCRIPTION
### Summary
Reintroducing support for the `object` type

#### Details
This is built on top of the general `neil-readd-types` branch. It reintroduces support for:
- The type in `SchemaTypes`
- Using `object` as a parameter
- Object property workflow step output access
- Object property runtime access
- Unsupported objects (no defined `properties`)
- Manifest auto-registration for `types` and `datastores`

While verifying I identified two pre-existing bugs that I entered tickets for:
- [Deno SDK — Typeahead does not work for an Object parameter's `required` field](https://jira.tinyspeck.com/browse/HERMES-3054)
- [Deno Client — Datastore attributes of type object do not give typeahead](https://jira.tinyspeck.com/browse/HERMES-3055)