### PR TITLE
Add definetype definition

### DIFF
--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -99,6 +99,100 @@ Deno.test("Manifest() automatically registers types used by function input and o
   });
 });
 
+Deno.test("Manifest() properly converts name to proper key", () => {
+  const UsingName = DefineType({
+    name: "Using Name",
+    type: Schema.types.boolean,
+  });
+
+  const Function = DefineFunction(
+    {
+      callback_id: "test_function",
+      title: "Function title",
+      source_file: "functions/test_function.ts",
+      input_parameters: {
+        properties: { aType: { type: UsingName } },
+        required: [],
+      },
+    },
+  );
+
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    longDescription: "LongDescription",
+    botScopes: [],
+    functions: [Function],
+  };
+  const manifest = Manifest(definition);
+  assertEquals(manifest.types, { "Using Name": { type: "boolean" } });
+});
+
+Deno.test("Manifest() properly converts callback_id to proper key", () => {
+  const UsingCallback = DefineType({
+    callback_id: "Using Callback",
+    type: Schema.types.boolean,
+  });
+
+  const Function = DefineFunction(
+    {
+      callback_id: "test_function",
+      title: "Function title",
+      source_file: "functions/test_function.ts",
+      input_parameters: {
+        properties: { aType: { type: UsingCallback } },
+        required: [],
+      },
+    },
+  );
+
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    longDescription: "LongDescription",
+    botScopes: [],
+    functions: [Function],
+  };
+  const manifest = Manifest(definition);
+  assertEquals(manifest.types, { "Using Callback": { type: "boolean" } });
+});
+
+Deno.test("Manifest() properly uses name over callback_id to proper key", () => {
+  const UsingName = DefineType({
+    callback_id: "Using Callback",
+    name: "Using Name",
+    type: Schema.types.boolean,
+  });
+
+  const Function = DefineFunction(
+    {
+      callback_id: "test_function",
+      title: "Function title",
+      source_file: "functions/test_function.ts",
+      input_parameters: {
+        properties: { aType: { type: UsingName } },
+        required: [],
+      },
+    },
+  );
+
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    longDescription: "LongDescription",
+    botScopes: [],
+    functions: [Function],
+  };
+  const manifest = Manifest(definition);
+  console.log(manifest);
+  assertEquals(manifest.types, {
+    "Using Name": { callback_id: "Using Callback", type: "boolean" },
+  });
+});
+
 Deno.test("Manifest() automatically registers types referenced by datastores", () => {
   const stringTypeId = "test_string_type";
   const StringType = DefineType({

--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -105,25 +105,13 @@ Deno.test("Manifest() properly converts name to proper key", () => {
     type: Schema.types.boolean,
   });
 
-  const Function = DefineFunction(
-    {
-      callback_id: "test_function",
-      title: "Function title",
-      source_file: "functions/test_function.ts",
-      input_parameters: {
-        properties: { aType: { type: UsingName } },
-        required: [],
-      },
-    },
-  );
-
   const definition: SlackManifestType = {
     name: "Name",
     description: "Description",
     icon: "icon.png",
     longDescription: "LongDescription",
     botScopes: [],
-    functions: [Function],
+    types: [UsingName],
   };
   const manifest = Manifest(definition);
   assertEquals(manifest.types, { "Using Name": { type: "boolean" } });
@@ -135,62 +123,16 @@ Deno.test("Manifest() properly converts callback_id to proper key", () => {
     type: Schema.types.boolean,
   });
 
-  const Function = DefineFunction(
-    {
-      callback_id: "test_function",
-      title: "Function title",
-      source_file: "functions/test_function.ts",
-      input_parameters: {
-        properties: { aType: { type: UsingCallback } },
-        required: [],
-      },
-    },
-  );
-
   const definition: SlackManifestType = {
     name: "Name",
     description: "Description",
     icon: "icon.png",
     longDescription: "LongDescription",
     botScopes: [],
-    functions: [Function],
+    types: [UsingCallback],
   };
   const manifest = Manifest(definition);
   assertEquals(manifest.types, { "Using Callback": { type: "boolean" } });
-});
-
-Deno.test("Manifest() properly uses name over callback_id to proper key", () => {
-  const UsingName = DefineType({
-    callback_id: "Using Callback",
-    name: "Using Name",
-    type: Schema.types.boolean,
-  });
-
-  const Function = DefineFunction(
-    {
-      callback_id: "test_function",
-      title: "Function title",
-      source_file: "functions/test_function.ts",
-      input_parameters: {
-        properties: { aType: { type: UsingName } },
-        required: [],
-      },
-    },
-  );
-
-  const definition: SlackManifestType = {
-    name: "Name",
-    description: "Description",
-    icon: "icon.png",
-    longDescription: "LongDescription",
-    botScopes: [],
-    functions: [Function],
-  };
-  const manifest = Manifest(definition);
-  console.log(manifest);
-  assertEquals(manifest.types, {
-    "Using Name": { callback_id: "Using Callback", type: "boolean" },
-  });
 });
 
 Deno.test("Manifest() automatically registers types referenced by datastores", () => {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -17,12 +17,7 @@ export class CustomType<Def extends CustomTypeDefinition>
   constructor(
     public definition: Def,
   ) {
-    this.id = "";
-    if ("name" in definition) {
-      this.id = definition.name;
-    } else if ("callback_id" in definition) {
-      this.id = definition.callback_id;
-    }
+    this.id = "name" in definition ? definition.name : definition.callback_id;
     this.definition = definition;
     this.description = definition.description;
     this.title = definition.title;
@@ -59,14 +54,12 @@ export class CustomType<Def extends CustomTypeDefinition>
   }
   export(): ManifestCustomTypeSchema {
     // remove callback_id or name from the definition we pass to the manifest
-    if ("callback_id" in this.definition) {
-      const { callback_id: _c, ...definition } = this.definition;
-      return definition;
-    } else if ("name" in this.definition) {
+    if ("name" in this.definition) {
       const { name: _n, ...definition } = this.definition;
       return definition;
     } else {
-      return this.definition;
+      const { callback_id: _c, ...definition } = this.definition;
+      return definition;
     }
   }
 }

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -1,25 +1,31 @@
 import { SlackManifest } from "../manifest.ts";
 import { ManifestCustomTypeSchema } from "../types.ts";
-import { CustomTypeDefinition, ICustomType } from "./types.ts";
+import {
+  CallbackTypeDefinition,
+  ICustomType,
+  NameTypeDefinition,
+} from "./types.ts";
 
-export const DefineType = <Def extends CustomTypeDefinition>(
-  definition: Def,
-) => {
+export function DefineType(name: NameTypeDefinition): CustomType;
+/**
+ * @deprecated Use name instead of callback_id
+ */
+export function DefineType(callback: CallbackTypeDefinition): CustomType;
+export function DefineType(
+  definition: NameTypeDefinition | CallbackTypeDefinition,
+) {
   return new CustomType(definition);
-};
+}
 
-export class CustomType<Def extends CustomTypeDefinition>
-  implements ICustomType {
+export class CustomType implements ICustomType {
   public id: string;
   public title: string | undefined;
   public description: string | undefined;
 
   constructor(
-    public definition: Def,
+    public definition: NameTypeDefinition | CallbackTypeDefinition,
   ) {
-    this.id = "name" in definition
-      ? (definition.name as string) // #TODO: Look into why this is requiring a cast as string
-      : definition.callback_id;
+    this.id = "name" in definition ? definition.name : definition.callback_id;
     this.definition = definition;
     this.description = definition.description;
     this.title = definition.title;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -17,7 +17,12 @@ export class CustomType<Def extends CustomTypeDefinition>
   constructor(
     public definition: Def,
   ) {
-    this.id = definition.callback_id;
+    this.id = "";
+    if ("name" in definition) {
+      this.id = definition.name;
+    } else if ("callback_id" in definition) {
+      this.id = definition.callback_id;
+    }
     this.definition = definition;
     this.description = definition.description;
     this.title = definition.title;
@@ -53,8 +58,16 @@ export class CustomType<Def extends CustomTypeDefinition>
     }
   }
   export(): ManifestCustomTypeSchema {
-    // remove callback_id from the definition we pass to the manifest
-    const { callback_id: _c, ...definition } = this.definition;
-    return definition;
+    // remove callback_id or name from the definition we pass to the manifest
+    console.log("TEST");
+    if ("callback_id" in this.definition) {
+      const { callback_id: _c, ...definition } = this.definition;
+      return definition;
+    } else if ("name" in this.definition) {
+      const { name: _n, ...definition } = this.definition;
+      return definition;
+    } else {
+      return this.definition;
+    }
   }
 }

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -59,7 +59,6 @@ export class CustomType<Def extends CustomTypeDefinition>
   }
   export(): ManifestCustomTypeSchema {
     // remove callback_id or name from the definition we pass to the manifest
-    console.log("TEST");
     if ("callback_id" in this.definition) {
       const { callback_id: _c, ...definition } = this.definition;
       return definition;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -6,24 +6,31 @@ import {
   NameTypeDefinition,
 } from "./types.ts";
 
-export function DefineType(name: NameTypeDefinition): CustomType;
+export function DefineType<Def extends NameTypeDefinition>(
+  name: Def,
+): CustomType<Def>;
 /**
  * @deprecated Use name instead of callback_id
  */
-export function DefineType(callback: CallbackTypeDefinition): CustomType;
-export function DefineType(
-  definition: NameTypeDefinition | CallbackTypeDefinition,
+export function DefineType<Def extends CallbackTypeDefinition>(
+  callback: Def,
+): CustomType<Def>;
+export function DefineType<
+  Def extends CallbackTypeDefinition | NameTypeDefinition,
+>(
+  definition: Def,
 ) {
   return new CustomType(definition);
 }
 
-export class CustomType implements ICustomType {
+export class CustomType<Def extends NameTypeDefinition | CallbackTypeDefinition>
+  implements ICustomType {
   public id: string;
   public title: string | undefined;
   public description: string | undefined;
 
   constructor(
-    public definition: NameTypeDefinition | CallbackTypeDefinition,
+    public definition: Def,
   ) {
     this.id = "name" in definition ? definition.name : definition.callback_id;
     this.definition = definition;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -18,7 +18,7 @@ export class CustomType<Def extends CustomTypeDefinition>
     public definition: Def,
   ) {
     this.id = "name" in definition
-      ? (definition.name as string)
+      ? (definition.name as string) // #TODO: Look into why this is requiring a cast as string
       : definition.callback_id;
     this.definition = definition;
     this.description = definition.description;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -17,7 +17,9 @@ export class CustomType<Def extends CustomTypeDefinition>
   constructor(
     public definition: Def,
   ) {
-    this.id = "name" in definition ? definition.name : definition.callback_id;
+    this.id = "name" in definition
+      ? (definition.name as string)
+      : definition.callback_id;
     this.definition = definition;
     this.description = definition.description;
     this.title = definition.title;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,7 +4,12 @@ import { ManifestCustomTypeSchema } from "../types.ts";
 
 export type CustomTypeDefinition =
   | (
-    & { callback_id: string }
+    & {
+      /**
+       * @deprecated Use name instead
+       */
+      callback_id: string;
+    }
     & TypedParameterDefinition
   )
   | (

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,14 +2,15 @@ import { TypedParameterDefinition } from "../parameters/types.ts";
 import { SlackManifest } from "../manifest.ts";
 import { ManifestCustomTypeSchema } from "../types.ts";
 
-export type CustomTypeDefinition = (
-  | { callback_id?: never; name: string }
+export type CustomTypeDefinition =
+  | (
+    & { callback_id?: never; name: string }
     & TypedParameterDefinition
+  )
   | (
     & { callback_id: string; name?: never }
     & TypedParameterDefinition
-  )
-);
+  );
 
 export interface ICustomType {
   id: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,19 +2,16 @@ import { TypedParameterDefinition } from "../parameters/types.ts";
 import { SlackManifest } from "../manifest.ts";
 import { ManifestCustomTypeSchema } from "../types.ts";
 
-export type CustomTypeDefinition =
-  | (
-    & { callback_id?: never; name: string }
-    & TypedParameterDefinition
-  )
-  | (
-    & { callback_id: string; name?: never }
-    & TypedParameterDefinition
-  );
+export type NameTypeDefinition =
+  & { name: string }
+  & TypedParameterDefinition;
+export type CallbackTypeDefinition =
+  & { callback_id: string }
+  & TypedParameterDefinition;
 
 export interface ICustomType {
   id: string;
-  definition: CustomTypeDefinition;
+  definition: CallbackTypeDefinition | NameTypeDefinition;
   description?: string;
   registerParameterTypes: (manifest: SlackManifest) => void;
   export(): ManifestCustomTypeSchema;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,20 +2,14 @@ import { TypedParameterDefinition } from "../parameters/types.ts";
 import { SlackManifest } from "../manifest.ts";
 import { ManifestCustomTypeSchema } from "../types.ts";
 
-export type CustomTypeDefinition =
+export type CustomTypeDefinition = (
+  | { callback_id?: never; name: string }
+    & TypedParameterDefinition
   | (
-    & {
-      /**
-       * @deprecated Use name instead
-       */
-      callback_id: string;
-    }
+    & { callback_id: string; name?: never }
     & TypedParameterDefinition
   )
-  | (
-    & { name: string }
-    & TypedParameterDefinition
-  );
+);
 
 export interface ICustomType {
   id: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,8 +3,14 @@ import { SlackManifest } from "../manifest.ts";
 import { ManifestCustomTypeSchema } from "../types.ts";
 
 export type CustomTypeDefinition =
-  & { callback_id: string }
-  & TypedParameterDefinition;
+  | (
+    & { callback_id: string }
+    & TypedParameterDefinition
+  )
+  | (
+    & { name: string }
+    & TypedParameterDefinition
+  );
 
 export interface ICustomType {
   id: string;

--- a/src/types/types_test.ts
+++ b/src/types/types_test.ts
@@ -1,0 +1,84 @@
+import { DefineType } from "./mod.ts";
+import { assertEquals } from "../dev_deps.ts";
+
+Deno.test("DefineType test against id using the name parameter", () => {
+  const Type = DefineType({
+    title: "Title",
+    description: "Description",
+    name: "Name",
+    type: "Type",
+  });
+
+  assertEquals(Type.id, "Name");
+});
+
+Deno.test("DefineType test against id using the callback_id parameter", () => {
+  const Type = DefineType({
+    title: "Title",
+    description: "Description",
+    callback_id: "Callback_id",
+    type: "Type",
+  });
+
+  assertEquals(Type.id, "Callback_id");
+});
+
+Deno.test("DefineType test topString using the callback_id parameter", () => {
+  const Type = DefineType({
+    title: "Title",
+    description: "Description",
+    callback_id: "Callback_id",
+    type: "Type",
+  });
+
+  const typeString = Type.toString();
+
+  assertEquals(typeString, "#/types/Callback_id");
+});
+
+Deno.test("DefineType test toString using the name parameter", () => {
+  const Type = DefineType({
+    title: "Title",
+    description: "Description",
+    name: "Name",
+    type: "Type",
+  });
+
+  const typeJson = Type.toJSON();
+
+  assertEquals(typeJson, "#/types/Name");
+});
+
+Deno.test("DefineType test export using the name parameter", () => {
+  const Type = DefineType({
+    title: "Title",
+    description: "Description",
+    name: "Name",
+    type: "Type",
+  });
+
+  const exportType = Type.export();
+
+  assertEquals(exportType, {
+    title: "Title",
+    description: "Description",
+    type: "Type",
+  });
+});
+
+Deno.test("DefineType test export using the callback_id parameter", () => {
+  const Type = DefineType({
+    title: "Title",
+    description: "Description",
+    callback_id: "Callback_id",
+    type: "Type",
+  });
+
+  const exportType = Type.export();
+
+  assertEquals(exportType, {
+    title: "Title",
+    description: "Description",
+    type: "Type",
+  });
+});

--- a/src/types/types_test.ts
+++ b/src/types/types_test.ts
@@ -23,7 +23,7 @@ Deno.test("DefineType test against id using the callback_id parameter", () => {
   assertEquals(Type.id, "Callback_id");
 });
 
-Deno.test("DefineType test topString using the callback_id parameter", () => {
+Deno.test("DefineType test toString using the callback_id parameter", () => {
   const Type = DefineType({
     title: "Title",
     description: "Description",


### PR DESCRIPTION
###  Summary

We want to deprecate the function call for DefineType when a callback_id is used as an input parameter. I Split the CustomTypeDefinition type into two separate types for name and callback_id respectively and creating a function overload for defineType that recognizes which type is being used in order to support deprecation

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
