### PR TITLE
Danielhw deprecated definetype function

### DIFF
--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -1,25 +1,31 @@
 import { SlackManifest } from "../manifest.ts";
 import { ManifestCustomTypeSchema } from "../types.ts";
-import { CustomTypeDefinition, ICustomType } from "./types.ts";
+import {
+  CallbackTypeDefinition,
+  ICustomType,
+  NameTypeDefinition,
+} from "./types.ts";
 
-export const DefineType = <Def extends CustomTypeDefinition>(
-  definition: Def,
-) => {
+export function DefineType(name: NameTypeDefinition): CustomType;
+/**
+ * @deprecated Use name instead of callback_id
+ */
+export function DefineType(callback: CallbackTypeDefinition): CustomType;
+export function DefineType(
+  definition: NameTypeDefinition | CallbackTypeDefinition,
+) {
   return new CustomType(definition);
-};
+}
 
-export class CustomType<Def extends CustomTypeDefinition>
-  implements ICustomType {
+export class CustomType implements ICustomType {
   public id: string;
   public title: string | undefined;
   public description: string | undefined;
 
   constructor(
-    public definition: Def,
+    public definition: NameTypeDefinition | CallbackTypeDefinition,
   ) {
-    this.id = "name" in definition
-      ? (definition.name as string) // #TODO: Look into why this is requiring a cast as string
-      : definition.callback_id;
+    this.id = "name" in definition ? definition.name : definition.callback_id;
     this.definition = definition;
     this.description = definition.description;
     this.title = definition.title;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -6,22 +6,21 @@ import {
   NameTypeDefinition,
 } from "./types.ts";
 
-export function DefineType<Def extends NameTypeDefinition>(
-  name: Def,
-): CustomType<Def>;
-/**
- * @deprecated Use name instead of callback_id
- */
-export function DefineType<Def extends CallbackTypeDefinition>(
-  callback: Def,
-): CustomType<Def>;
-export function DefineType<
-  Def extends CallbackTypeDefinition | NameTypeDefinition,
+type DefineTypeType = {
+  <Def extends NameTypeDefinition>(name: Def): CustomType<Def>;
+  /**
+   * @deprecated Use name instead of callback_id
+   */
+  <Def extends CallbackTypeDefinition>(callback_id: Def): CustomType<Def>;
+};
+
+export const DefineType: DefineTypeType = <
+  Def extends NameTypeDefinition | CallbackTypeDefinition,
 >(
   definition: Def,
-) {
+) => {
   return new CustomType(definition);
-}
+};
 
 export class CustomType<Def extends NameTypeDefinition | CallbackTypeDefinition>
   implements ICustomType {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -6,24 +6,31 @@ import {
   NameTypeDefinition,
 } from "./types.ts";
 
-export function DefineType(name: NameTypeDefinition): CustomType;
+export function DefineType<Def extends NameTypeDefinition>(
+  name: Def,
+): CustomType<Def>;
 /**
  * @deprecated Use name instead of callback_id
  */
-export function DefineType(callback: CallbackTypeDefinition): CustomType;
-export function DefineType(
-  definition: NameTypeDefinition | CallbackTypeDefinition,
+export function DefineType<Def extends CallbackTypeDefinition>(
+  callback: Def,
+): CustomType<Def>;
+export function DefineType<
+  Def extends CallbackTypeDefinition | NameTypeDefinition,
+>(
+  definition: Def,
 ) {
   return new CustomType(definition);
 }
 
-export class CustomType implements ICustomType {
+export class CustomType<Def extends NameTypeDefinition | CallbackTypeDefinition>
+  implements ICustomType {
   public id: string;
   public title: string | undefined;
   public description: string | undefined;
 
   constructor(
-    public definition: NameTypeDefinition | CallbackTypeDefinition,
+    public definition: Def,
   ) {
     this.id = "name" in definition ? definition.name : definition.callback_id;
     this.definition = definition;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,19 +2,16 @@ import { TypedParameterDefinition } from "../parameters/types.ts";
 import { SlackManifest } from "../manifest.ts";
 import { ManifestCustomTypeSchema } from "../types.ts";
 
-export type CustomTypeDefinition =
-  | (
-    & { callback_id?: never; name: string }
-    & TypedParameterDefinition
-  )
-  | (
-    & { callback_id: string; name?: never }
-    & TypedParameterDefinition
-  );
+export type NameTypeDefinition =
+  & { name: string }
+  & TypedParameterDefinition;
+export type CallbackTypeDefinition =
+  & { callback_id: string }
+  & TypedParameterDefinition;
 
 export interface ICustomType {
   id: string;
-  definition: CustomTypeDefinition;
+  definition: CallbackTypeDefinition | NameTypeDefinition;
   description?: string;
   registerParameterTypes: (manifest: SlackManifest) => void;
   export(): ManifestCustomTypeSchema;


### PR DESCRIPTION
###  Summary

We want to deprecate the function call for DefineType when a callback_id is used as an input parameter. I Split the CustomTypeDefinition type into two separate types for name and callback_id respectively and creating a function overload for defineType that recognizes which type is being used in order to support deprecation

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
