### PR TITLE
Support for read_only_message_tab

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -43,6 +43,10 @@ export class SlackManifest {
         bot_user: {
           display_name: def.displayName || def.name,
         },
+        app_home: {
+          messages_tab_enabled: true,
+          messages_tab_read_only_enabled: true,
+        },
       },
       outgoing_domains: def.outgoingDomains || [],
     };
@@ -88,11 +92,16 @@ export class SlackManifest {
     }
 
     if (def.features?.appHome) {
-      manifest.features.app_home = {
-        messages_tab_enabled: def.features?.appHome.messagesTabEnabled,
-        messages_tab_read_only_enabled:
-          def.features?.appHome.messagesTabReadOnlyEnabled ?? true,
-      };
+      const { messagesTabEnabled, messagesTabReadOnlyEnabled } =
+        def.features.appHome;
+
+      if (messagesTabEnabled !== undefined) {
+        manifest.features.app_home.messages_tab_enabled = messagesTabEnabled;
+      }
+      if (messagesTabReadOnlyEnabled !== undefined) {
+        manifest.features.app_home.messages_tab_read_only_enabled =
+          messagesTabReadOnlyEnabled;
+      }
     }
 
     return manifest;

--- a/src/manifest_test.ts
+++ b/src/manifest_test.ts
@@ -360,3 +360,53 @@ Deno.test("SlackManifest.export() will not duplicate datastore scopes if they're
     1,
   );
 });
+
+Deno.test("SlackManifest.export() defaults to enabling the read only messages tab", () => {
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    botScopes: [],
+  };
+
+  const Manifest = new SlackManifest(definition);
+  const exportedManifest = Manifest.export();
+  exportedManifest.features.app_home?.messages_tab_enabled;
+  exportedManifest.features.app_home?.messages_tab_read_only_enabled;
+  assertStrictEquals(
+    exportedManifest.features.app_home?.messages_tab_enabled,
+    true,
+  );
+  assertStrictEquals(
+    exportedManifest.features.app_home?.messages_tab_read_only_enabled,
+    true,
+  );
+});
+
+Deno.test("SlackManifest.export() allows overriding app home features", () => {
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    botScopes: [],
+    features: {
+      appHome: {
+        messagesTabEnabled: false,
+        messagesTabReadOnlyEnabled: false,
+      },
+    },
+  };
+
+  const Manifest = new SlackManifest(definition);
+  const exportedManifest = Manifest.export();
+  exportedManifest.features.app_home?.messages_tab_enabled;
+  exportedManifest.features.app_home?.messages_tab_read_only_enabled;
+  assertStrictEquals(
+    exportedManifest.features.app_home?.messages_tab_enabled,
+    false,
+  );
+  assertStrictEquals(
+    exportedManifest.features.app_home?.messages_tab_read_only_enabled,
+    false,
+  );
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,16 @@ export type {
   SlackFunctionHandler,
 } from "./functions/types.ts";
 
+export interface SlackManifestFeaturesAppHome {
+  messagesTabEnabled?: boolean;
+  // @default true
+  messagesTabReadOnlyEnabled?: boolean;
+}
+
+export interface SlackManifestFeatures {
+  appHome?: SlackManifestFeaturesAppHome;
+}
+
 export type SlackManifestType = {
   name: string;
   backgroundColor?: string;
@@ -29,6 +39,7 @@ export type SlackManifestType = {
   outgoingDomains?: Array<string>;
   types?: ICustomType[];
   datastores?: ManifestDatastore[];
+  features?: SlackManifestFeatures;
 };
 
 export type ManifestDatastore = ISlackDatastore;
@@ -50,8 +61,8 @@ export type InvocationPayload<Body> = {
   // TODO: type this out to handle multiple body types
   body: Body;
   context: {
-    "bot_access_token": string;
-    "variables": Record<string, string>;
+    bot_access_token: string;
+    variables: Record<string, string>;
   };
 };
 
@@ -81,12 +92,14 @@ export type ManifestFunctionSchema = {
   title?: string;
   description?: string;
   source_file: string;
-  "input_parameters": ManifestFunctionParameters;
-  "output_parameters": ManifestFunctionParameters;
+  input_parameters: ManifestFunctionParameters;
+  output_parameters: ManifestFunctionParameters;
 };
 
+export type ManifestFunctionsSchema = { [key: string]: ManifestFunctionSchema };
+
 export type ManifestDatastoreSchema = {
-  "primary_key": string;
+  primary_key: string;
   attributes: {
     [key: string]: {
       type: string | ICustomType;
@@ -98,9 +111,13 @@ export type ManifestDatastoreSchema = {
   };
 };
 
+export type ManifestDataStoresSchema = {
+  [key: string]: ManifestDatastoreSchema;
+};
+
 export type ManifestWorkflowStepSchema = {
   id: string;
-  "function_id": string;
+  function_id: string;
   inputs: {
     [name: string]: unknown;
   };
@@ -109,47 +126,51 @@ export type ManifestWorkflowStepSchema = {
 export type ManifestWorkflowSchema = {
   title?: string;
   description?: string;
-  "input_parameters"?: ManifestFunctionParameters;
+  input_parameters?: ManifestFunctionParameters;
   steps: ManifestWorkflowStepSchema[];
 };
 
+export type ManifestWorkflowsSchema = { [key: string]: ManifestWorkflowSchema };
+
 export type ManifestCustomTypeSchema = ParameterDefinition;
 
+export type ManifestCustomTypesSchema = { [key: string]: ParameterDefinition };
+
 export type ManifestMetadata = {
-  "major_version"?: number;
-  "minor_version"?: number;
+  major_version?: number;
+  minor_version?: number;
 };
 
+export interface ManifestFeaturesAppHome {
+  messages_tab_enabled?: boolean;
+  messages_tab_read_only_enabled?: boolean;
+}
+
+export interface ManifestFeaturesSchema {
+  bot_user: {
+    display_name: string;
+  };
+  app_home?: ManifestFeaturesAppHome;
+}
+
 export type ManifestSchema = {
-  "_metadata"?: ManifestMetadata;
-  "display_information": {
-    "background_color"?: string;
+  _metadata?: ManifestMetadata;
+  display_information: {
+    background_color?: string;
     name: string;
-    "long_description"?: string;
-    "short_description": string;
+    long_description?: string;
+    short_description: string;
   };
   icon: string;
-  "oauth_config": {
+  oauth_config: {
     scopes: {
       bot: string[];
     };
   };
-  features: {
-    "bot_user": {
-      "display_name": string;
-    };
-  };
-  functions?: {
-    [key: string]: ManifestFunctionSchema;
-  };
-  workflows?: {
-    [key: string]: ManifestWorkflowSchema;
-  };
-  "outgoing_domains"?: string[];
-  types?: {
-    [key: string]: ManifestCustomTypeSchema;
-  };
-  datastores?: {
-    [key: string]: ManifestDatastoreSchema;
-  };
+  features: ManifestFeaturesSchema;
+  functions?: ManifestFunctionsSchema;
+  workflows?: ManifestWorkflowsSchema;
+  outgoing_domains?: string[];
+  types?: ManifestCustomTypesSchema;
+  datastores?: ManifestDataStoresSchema;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,11 +16,20 @@ export type {
   SlackFunctionHandler,
 } from "./functions/types.ts";
 
-export interface SlackManifestFeaturesAppHome {
-  messagesTabEnabled?: boolean;
-  // @default true
+export type SlackManifestFeaturesAppHome = AppHomeMessagesTab;
+
+// TODO: Find way to share these defaults
+type AppHomeMessagesTab = {
+  /** @default true */
+  messagesTabEnabled?: true;
+  /** @default true */
   messagesTabReadOnlyEnabled?: boolean;
-}
+} | {
+  /** @default true */
+  messagesTabEnabled: false;
+  /** @default true */
+  messagesTabReadOnlyEnabled: false;
+};
 
 export interface SlackManifestFeatures {
   appHome?: SlackManifestFeaturesAppHome;
@@ -134,7 +143,9 @@ export type ManifestWorkflowsSchema = { [key: string]: ManifestWorkflowSchema };
 
 export type ManifestCustomTypeSchema = ParameterDefinition;
 
-export type ManifestCustomTypesSchema = { [key: string]: ParameterDefinition };
+export type ManifestCustomTypesSchema = {
+  [key: string]: ManifestCustomTypeSchema;
+};
 
 export type ManifestMetadata = {
   major_version?: number;
@@ -150,7 +161,7 @@ export interface ManifestFeaturesSchema {
   bot_user: {
     display_name: string;
   };
-  app_home?: ManifestFeaturesAppHome;
+  app_home: ManifestFeaturesAppHome;
 }
 
 export type ManifestSchema = {


### PR DESCRIPTION
###  Summary

Adding a support to enable message tab in the app profile.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
