### PR TITLE
First pass at Action Handlers / a router for actions

### DIFF
--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,5 +1,6 @@
 export {
   assertEquals,
   assertExists,
+  assertMatch,
   assertStrictEquals,
 } from "https://deno.land/std@0.134.0/testing/asserts.ts";

--- a/src/functions/routers/action_router.ts
+++ b/src/functions/routers/action_router.ts
@@ -133,8 +133,10 @@ export class ActionsRouter<
         // Assumes an object as a constraint (type BlockActionConstraintObject)
         // Return first match *within* any of the defined fields on the constaint object, but ensure there is a match on *all* defined fields
         // Effectively a logical AND across the action_id and block_id field(s)
-        let actionIDMatched = false;
-        let blockIDMatched = false;
+        // If either of the constraint fields are not defined, pre-set them to have matched so we can effectively
+        // ignore them when determining if we have a match by &&'ing them
+        let actionIDMatched = constraint.action_id ? false : true;
+        let blockIDMatched = constraint.block_id ? false : true;
         if (constraint.action_id) {
           actionIDMatched = matchBlockActionConstraintField(
             normalizeConstraintToArray(constraint.action_id),
@@ -149,12 +151,7 @@ export class ActionsRouter<
             action,
           );
         }
-        if (
-          (constraint.block_id && constraint.action_id && blockIDMatched &&
-            actionIDMatched) ||
-          (constraint.block_id && blockIDMatched) ||
-          (constraint.action_id && actionIDMatched)
-        ) {
+        if (blockIDMatched && actionIDMatched) {
           return handler;
         }
       }

--- a/src/functions/routers/action_router.ts
+++ b/src/functions/routers/action_router.ts
@@ -1,0 +1,191 @@
+import {
+  ParameterSetDefinition,
+  PossibleParameterKeys,
+} from "../../parameters/mod.ts";
+import { SlackFunction } from "../mod.ts";
+import type {
+  BlockAction,
+  BlockActionConstraint,
+  BlockActionConstraintField,
+  BlockActionConstraintObject,
+  BlockActionHandler,
+} from "./types.ts";
+
+/**
+ * Define an actions "router" and its input and output parameters for use in a Slack application. The ActionsRouter will route incoming action events to action-specific handlers.
+ * @param {SlackFunction<InputParameters, OutputParameters, RequiredInput, RequiredOutput>} func Reference to your previously-created SlackFunction, defined via DefineFunction
+ * @returns {ActionsRouter}
+ */
+export const BlockActionsRouter = <
+  InputParameters extends ParameterSetDefinition,
+  OutputParameters extends ParameterSetDefinition,
+  RequiredInput extends PossibleParameterKeys<InputParameters>,
+  RequiredOutput extends PossibleParameterKeys<OutputParameters>,
+>(
+  func: SlackFunction<
+    InputParameters,
+    OutputParameters,
+    RequiredInput,
+    RequiredOutput
+  >,
+) => {
+  const router = new ActionsRouter(func);
+
+  // deno-lint-ignore no-explicit-any
+  const exportedHandler: any = router.export();
+
+  // deno-lint-ignore no-explicit-any
+  exportedHandler.addHandler = ((...args: any) => {
+    router.addHandler.apply(router, args);
+
+    return exportedHandler;
+  }) as typeof router.addHandler;
+
+  return exportedHandler as
+    & ReturnType<typeof router.export>
+    & Pick<typeof router, "addHandler">;
+};
+
+export class ActionsRouter<
+  InputParameters extends ParameterSetDefinition,
+  OutputParameters extends ParameterSetDefinition,
+  RequiredInput extends PossibleParameterKeys<InputParameters>,
+  RequiredOutput extends PossibleParameterKeys<OutputParameters>,
+> {
+  private routes: Array<
+    [BlockActionConstraint, BlockActionHandler<typeof this.func.definition>]
+  >;
+
+  constructor(
+    private func: SlackFunction<
+      InputParameters,
+      OutputParameters,
+      RequiredInput,
+      RequiredOutput
+    >,
+  ) {
+    this.func = func;
+    this.routes = [];
+  }
+
+  /**
+   * Add an action handler for something that can match an action event.
+   * @param {BlockActionConstraint} actionConstraint A BlockActionConstraintField(i.e. a string, array of strings or regular expression) or more complex BlockActionConstraintObject to match incoming block action events. A BlockActionConstraintField parameter are matched with a block action event's `action_id` property. A BlockActionConstraintObject parameter allows to match with other block action event properties like `block_id` as well as `action_id`. If multiple properties are specified using BlockActionConstraintObject, then the event must match ALL provided BlockActionConstraintObject properties.
+   * @returns {ActionsRouter}
+   */
+  addHandler(
+    actionConstraint: BlockActionConstraint,
+    handler: BlockActionHandler<typeof this.func.definition>,
+  ): ActionsRouter<
+    InputParameters,
+    OutputParameters,
+    RequiredInput,
+    RequiredOutput
+  > {
+    this.routes.push([actionConstraint, handler]);
+    return this;
+  }
+
+  /**
+   * Returns a method handling routing of action payloads to the appropriate action handler.
+   * The output of export() should be attached to the `blockActions` export of your function.
+   */
+  export(): BlockActionHandler<typeof this.func.definition> {
+    return async (context) => {
+      const action: BlockAction = context.action;
+      const handler = this.matchHandler(action);
+      if (handler === null) {
+        // TODO: what do in this case?
+        // perhaps the user typo'ed the action id when registering their handler or defining their block.
+        // In the local-run case, this warning should be apparent to the user, but in the deployed context, this might be trickier to isolate
+        console.warn(
+          `Received block action payload with action=${
+            JSON.stringify(action)
+          } but this app has no action handler defined to handle it!`,
+        );
+        return;
+      }
+      return await handler(context);
+    };
+  }
+
+  /**
+   * Return the first registered ActionHandler that matches the action ID string provided.
+   */
+  matchHandler(
+    action: BlockAction,
+  ): BlockActionHandler<typeof this.func.definition> | null {
+    for (let i = 0; i < this.routes.length; i++) {
+      const route = this.routes[i];
+      let [constraint, handler] = route;
+      // Handle different constraint types below
+      if (
+        constraint instanceof RegExp || constraint instanceof Array ||
+        typeof constraint === "string"
+      ) {
+        // Normalize simple string constraints to be an array of strings for consistency in handling inside this method.
+        constraint = normalizeConstraintToArray(constraint);
+        // Handle the case where the constraint is either a regex or an array of strings to match against action_id
+        if (matchBlockActionConstraintField(constraint, "action_id", action)) {
+          return handler;
+        }
+      } else {
+        // Assumes an object as a constraint (type BlockActionConstraintObject)
+        // Return first match *within* any of the defined fields on the constaint object, but ensure there is a match on *all* defined fields
+        // Effectively a logical AND across the action_id and block_id field(s)
+        let actionIDMatched = false;
+        let blockIDMatched = false;
+        if (constraint.action_id) {
+          actionIDMatched = matchBlockActionConstraintField(
+            normalizeConstraintToArray(constraint.action_id),
+            "action_id",
+            action,
+          );
+        }
+        if (constraint.block_id) {
+          blockIDMatched = matchBlockActionConstraintField(
+            normalizeConstraintToArray(constraint.block_id),
+            "block_id",
+            action,
+          );
+        }
+        if (
+          (constraint.block_id && constraint.action_id && blockIDMatched &&
+            actionIDMatched) ||
+          (constraint.block_id && blockIDMatched) ||
+          (constraint.action_id && actionIDMatched)
+        ) {
+          return handler;
+        }
+      }
+    }
+    return null;
+  }
+}
+
+function normalizeConstraintToArray(constraint: BlockActionConstraintField) {
+  if (typeof constraint === "string") {
+    constraint = [constraint];
+  }
+  return constraint;
+}
+
+function matchBlockActionConstraintField(
+  constraint: BlockActionConstraintField,
+  field: keyof BlockActionConstraintObject,
+  action: BlockAction,
+) {
+  if (constraint instanceof RegExp) {
+    if (action[field].match(constraint)) {
+      return true;
+    }
+  } else if (constraint instanceof Array) {
+    for (let j = 0; j < constraint.length; j++) {
+      const c = constraint[j];
+      if (action[field] === c) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/functions/routers/action_router_test.ts
+++ b/src/functions/routers/action_router_test.ts
@@ -354,6 +354,498 @@ Deno.test("ActionsRouter", async (t) => {
         );
         console.warn = originalWarn;
       });
+      reset();
+      await t.step("no false positives", async (t) => {
+        // for these false positive tests, console.warn can be noisy, so lets turn it into a temporary no-op
+        const originalWarn = console.warn;
+        console.warn = () => {};
+        await t.step(
+          "not matching action_id: string",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler("nope", () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching action_id: string[]",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler(["nope", "nuh uh"], () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching action_id: regex",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler(/regex/, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string}",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({ action_id: "nope" }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string[]}",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({ action_id: ["nope", "nuh uh"] }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: regex}",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({ action_id: /regex/ }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {block_id: string}",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({ block_id: "nope" }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {block_id: string[]}",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({ block_id: ["nope", "nuh uh"] }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {block_id: regex}",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({ block_id: /regex/ }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string, block_id: regex}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: "not good enough",
+              block_id: /block/,
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string, block_id: regex}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: "action_id",
+              block_id: /noway/,
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string, block_id: string[]}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: "not good enough",
+              block_id: ["notthisonebut", "block_id"],
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string, block_id: string}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: "action_id",
+              block_id: ["this", "wont", "work"],
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string, block_id: string}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: "not good enough",
+              block_id: "block_id",
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string, block_id: string}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: "action_id",
+              block_id: "nicetry",
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string[], block_id: regex}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: ["not", "good", "enough"],
+              block_id: /block/,
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string[], block_id: regex}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: ["decoy", "action_id"],
+              block_id: /noway/,
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string[], block_id: string[]}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: ["not", "good", "enough"],
+              block_id: ["notthisonebut", "block_id"],
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string[], block_id: string}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: ["decoy", "action_id"],
+              block_id: ["this", "wont", "work"],
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string[], block_id: string}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: ["not", "good", "enough"],
+              block_id: "block_id",
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: string[], block_id: string}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: ["decoy", "action_id"],
+              block_id: "nicetry",
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: regex, block_id: regex}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: /heh/,
+              block_id: /block/,
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: regex, block_id: regex}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: /action/,
+              block_id: /noway/,
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: regex, block_id: string[]}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: /hah/,
+              block_id: ["notthisonebut", "block_id"],
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: regex, block_id: string}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: /action/,
+              block_id: ["this", "wont", "work"],
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: regex, block_id: string}, action_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: /huh/,
+              block_id: "block_id",
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        reset();
+        await t.step(
+          "not matching {action_id: regex, block_id: string}, block_id does not match",
+          async () => {
+            let handlerCalled = 0;
+            router.addHandler({
+              action_id: /action/,
+              block_id: "nicetry",
+            }, () => {
+              handlerCalled++;
+            });
+            await router(createContext({ inputs }));
+            assertEquals(
+              handlerCalled,
+              0,
+              "action handler called when it should not be",
+            );
+          },
+        );
+        console.warn = originalWarn;
+      });
     });
   });
 });

--- a/src/functions/routers/action_router_test.ts
+++ b/src/functions/routers/action_router_test.ts
@@ -1,0 +1,359 @@
+import { assertEquals, assertExists, assertMatch } from "../../dev_deps.ts";
+import { BlockActionsRouter } from "./action_router.ts";
+import { DefineFunction, Schema } from "../../mod.ts";
+import { DEFAULT_ACTION, SlackActionHandlerTester } from "../tester/mod.ts";
+
+// Test fixtures: a basic function definition and associated block action router to test
+const func = DefineFunction({
+  callback_id: "id",
+  title: "test",
+  source_file: "whatever",
+  input_parameters: {
+    properties: {
+      garbage: { type: Schema.types.string },
+    },
+    required: [],
+  },
+});
+const { createContext } = SlackActionHandlerTester(func);
+const inputs = { garbage: "in, garbage out" };
+let router = BlockActionsRouter(func);
+
+const reset = () => {
+  router = BlockActionsRouter(func);
+};
+
+Deno.test("ActionsRouter", async (t) => {
+  await t.step(
+    "export method returns result of handler when matching action comes in and baseline handler context parameters are present and exist",
+    async () => {
+      let handlerCalled = false;
+      router.addHandler(DEFAULT_ACTION.action_id, (ctx) => {
+        assertExists(ctx.inputs);
+        assertEquals<string>(ctx.inputs.garbage as string, inputs.garbage);
+        assertExists(ctx.token);
+        assertExists(ctx.action);
+        assertExists(ctx.env);
+        handlerCalled = true;
+      });
+      await router(createContext({ inputs }));
+      assertEquals(handlerCalled, true, "action handler not called!");
+    },
+  );
+  reset();
+  await t.step("action matching", async (t) => {
+    await t.step("happy path", async (t) => {
+      await t.step("simple string matching to action_id", async () => {
+        let handlerCalled = false;
+        router.addHandler(DEFAULT_ACTION.action_id, (ctx) => {
+          assertExists(ctx.inputs);
+          assertExists(ctx.token);
+          assertExists(ctx.action);
+          assertExists(ctx.env);
+          handlerCalled = true;
+        });
+        await router(createContext({ inputs }));
+        assertEquals(handlerCalled, true, "action handler not called!");
+      });
+      reset();
+      await t.step("array of strings matching to action_id", async () => {
+        let handlerCalled = 0;
+        router.addHandler(["nope", DEFAULT_ACTION.action_id], () => {
+          handlerCalled++;
+        });
+        await router(createContext({ inputs }));
+        assertEquals(
+          handlerCalled,
+          1,
+          "action handler not called exactly once",
+        );
+      });
+      reset();
+      await t.step("regex matching to action_id", async () => {
+        let handlerCalled = 0;
+        router.addHandler(/action/, () => {
+          handlerCalled++;
+        });
+        await router(createContext({ inputs }));
+        assertEquals(
+          handlerCalled,
+          1,
+          "action handler not called exactly once",
+        );
+      });
+      reset();
+      await t.step("{action_id:string} matching to action_id", async () => {
+        let handlerCalled = 0;
+        router.addHandler({ action_id: DEFAULT_ACTION.action_id }, () => {
+          handlerCalled++;
+        });
+        await router(createContext({ inputs }));
+        assertEquals(
+          handlerCalled,
+          1,
+          "action handler not called exactly once",
+        );
+      });
+      reset();
+      await t.step("{action_id:[string]} matching to action_id", async () => {
+        let handlerCalled = 0;
+        router.addHandler(
+          { action_id: ["hahtrickedyou", DEFAULT_ACTION.action_id] },
+          () => {
+            handlerCalled++;
+          },
+        );
+        await router(createContext({ inputs }));
+        assertEquals(
+          handlerCalled,
+          1,
+          "action handler not called exactly once",
+        );
+      });
+      reset();
+      await t.step("{action_id:regex} matching to action_id", async () => {
+        let handlerCalled = 0;
+        router.addHandler({ action_id: /action/ }, () => {
+          handlerCalled++;
+        });
+        await router(createContext({ inputs }));
+        assertEquals(
+          handlerCalled,
+          1,
+          "action handler not called exactly once",
+        );
+      });
+      reset();
+      await t.step("{block_id:string} matching to block_id", async () => {
+        let handlerCalled = 0;
+        router.addHandler({ block_id: DEFAULT_ACTION.block_id }, () => {
+          handlerCalled++;
+        });
+        await router(createContext({ inputs }));
+        assertEquals(
+          handlerCalled,
+          1,
+          "action handler not called exactly once",
+        );
+      });
+      reset();
+      await t.step("{block_id:[string]} matching to block_id", async () => {
+        let handlerCalled = 0;
+        router.addHandler(
+          { block_id: ["lol", DEFAULT_ACTION.block_id] },
+          () => {
+            handlerCalled++;
+          },
+        );
+        await router(createContext({ inputs }));
+        assertEquals(
+          handlerCalled,
+          1,
+          "action handler not called exactly once",
+        );
+      });
+      reset();
+      await t.step("{block_id:regex} matching to block_id", async () => {
+        let handlerCalled = 0;
+        router.addHandler({ block_id: /block/ }, () => {
+          handlerCalled++;
+        });
+        await router(createContext({ inputs }));
+        assertEquals(
+          handlerCalled,
+          1,
+          "action handler not called exactly once",
+        );
+      });
+      reset();
+      await t.step(
+        "{block_id:string, action_id:string} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler({
+            block_id: DEFAULT_ACTION.block_id,
+            action_id: DEFAULT_ACTION.action_id,
+          }, () => {
+            handlerCalled++;
+          });
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+      await t.step(
+        "{block_id:string, action_id:[string]} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler({
+            block_id: DEFAULT_ACTION.block_id,
+            action_id: ["notthisoneeither", DEFAULT_ACTION.action_id],
+          }, () => {
+            handlerCalled++;
+          });
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+      await t.step(
+        "{block_id:string, action_id:regex} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler(
+            { block_id: DEFAULT_ACTION.block_id, action_id: /action/ },
+            () => {
+              handlerCalled++;
+            },
+          );
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+      await t.step(
+        "{block_id:[string], action_id:string} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler({
+            block_id: ["notthistime", DEFAULT_ACTION.block_id],
+            action_id: DEFAULT_ACTION.action_id,
+          }, () => {
+            handlerCalled++;
+          });
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+      await t.step(
+        "{block_id:[string], action_id:[string]} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler({
+            block_id: ["notthistime", DEFAULT_ACTION.block_id],
+            action_id: ["gotyougood", DEFAULT_ACTION.action_id],
+          }, () => {
+            handlerCalled++;
+          });
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+      await t.step(
+        "{block_id:[string], action_id:regex} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler({
+            block_id: ["notthistime", DEFAULT_ACTION.block_id],
+            action_id: /action/,
+          }, () => {
+            handlerCalled++;
+          });
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+      await t.step(
+        "{block_id:regex, action_id:string} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler(
+            { block_id: /block/, action_id: DEFAULT_ACTION.action_id },
+            () => {
+              handlerCalled++;
+            },
+          );
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+      await t.step(
+        "{block_id:regex, action_id:[string]} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler({
+            block_id: /block/,
+            action_id: ["hahanope", DEFAULT_ACTION.action_id],
+          }, () => {
+            handlerCalled++;
+          });
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+      await t.step(
+        "{block_id:regex, action_id:regex} matching to both block_id and action_id",
+        async () => {
+          let handlerCalled = 0;
+          router.addHandler({ block_id: /block/, action_id: /action/ }, () => {
+            handlerCalled++;
+          });
+          await router(createContext({ inputs }));
+          assertEquals(
+            handlerCalled,
+            1,
+            "action handler not called exactly once",
+          );
+        },
+      );
+      reset();
+    });
+    reset();
+    await t.step("sad path", async (t) => {
+      await t.step("unhandled action should log to console", async () => {
+        const originalWarn = console.warn;
+        let warnCalled = 0;
+        // deno-lint-ignore no-explicit-any
+        console.warn = (...data: any[]) => {
+          warnCalled++;
+          const warn = data[0];
+          assertMatch(warn, /no action handler defined/);
+        };
+        await router(createContext({ inputs }));
+        assertEquals(
+          warnCalled,
+          1,
+          "console.warn not called exactly once",
+        );
+        console.warn = originalWarn;
+      });
+    });
+  });
+});

--- a/src/functions/routers/action_router_test.ts
+++ b/src/functions/routers/action_router_test.ts
@@ -12,7 +12,7 @@ const func = DefineFunction({
     properties: {
       garbage: { type: Schema.types.string },
     },
-    required: [],
+    required: ["garbage"],
   },
 });
 const { createContext } = SlackActionHandlerTester(func);
@@ -30,7 +30,7 @@ Deno.test("ActionsRouter", async (t) => {
       let handlerCalled = false;
       router.addHandler(DEFAULT_ACTION.action_id, (ctx) => {
         assertExists(ctx.inputs);
-        assertEquals<string>(ctx.inputs.garbage as string, inputs.garbage);
+        assertEquals<string>(ctx.inputs.garbage, inputs.garbage);
         assertExists(ctx.token);
         assertExists(ctx.action);
         assertExists(ctx.env);

--- a/src/functions/routers/mod.ts
+++ b/src/functions/routers/mod.ts
@@ -1,0 +1,1 @@
+export { BlockActionsRouter } from "./action_router.ts";

--- a/src/functions/routers/types.ts
+++ b/src/functions/routers/types.ts
@@ -28,7 +28,6 @@ export type BlockActionInvocationBody<
 > = {
   type: string;
   actions: BlockAction[];
-  bot_access_token?: string;
   function_data?: FunctionData<InputParameters>;
   // deno-lint-ignore no-explicit-any
   [key: string]: any;

--- a/src/functions/routers/types.ts
+++ b/src/functions/routers/types.ts
@@ -1,0 +1,62 @@
+import {
+  FunctionContext,
+  FunctionDefinitionArgs,
+  FunctionParameters,
+  FunctionRuntimeParameters,
+} from "../types.ts";
+
+export type BlockActionHandler<Definition> = Definition extends
+  FunctionDefinitionArgs<infer I, infer O, infer RI, infer RO> ? {
+    (
+      context: ActionContext<FunctionRuntimeParameters<I, RI>>,
+    ): Promise<void> | void;
+  }
+  : never;
+
+export type ActionContext<InputParameters> =
+  & Omit<FunctionContext<InputParameters>, "event">
+  & ActionSpecificContext<InputParameters>;
+
+type ActionSpecificContext<InputParameters extends FunctionParameters> = {
+  body: BlockActionInvocationBody<InputParameters>;
+  action: BlockAction;
+};
+
+// TODO: all below stolen from deno-slack-runtime, need to centralize these somewhere
+export type BlockActionInvocationBody<
+  InputParameters extends FunctionParameters,
+> = {
+  type: string;
+  actions: BlockAction[];
+  bot_access_token?: string;
+  function_data?: FunctionData<InputParameters>;
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
+};
+
+type FunctionData<InputParameters extends FunctionParameters> = {
+  function: {
+    callback_id: string;
+  };
+  execution_id: string;
+  inputs: InputParameters;
+};
+
+export type BlockAction = {
+  type: string;
+  block_id: string;
+  action_id: string;
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
+};
+
+export type BlockActionConstraint =
+  | BlockActionConstraintField
+  | BlockActionConstraintObject;
+
+export type BlockActionConstraintObject = {
+  block_id?: BlockActionConstraintField;
+  action_id?: BlockActionConstraintField;
+};
+
+export type BlockActionConstraintField = string | string[] | RegExp;

--- a/src/functions/routers/types.ts
+++ b/src/functions/routers/types.ts
@@ -9,7 +9,8 @@ export type BlockActionHandler<Definition> = Definition extends
   FunctionDefinitionArgs<infer I, infer O, infer RI, infer RO> ? {
     (
       context: ActionContext<FunctionRuntimeParameters<I, RI>>,
-    ): Promise<void> | void;
+      // deno-lint-ignore no-explicit-any
+    ): Promise<any> | any;
   }
   : never;
 
@@ -28,7 +29,7 @@ export type BlockActionInvocationBody<
 > = {
   type: string;
   actions: BlockAction[];
-  function_data?: FunctionData<InputParameters>;
+  function_data: FunctionData<InputParameters>;
   // deno-lint-ignore no-explicit-any
   [key: string]: any;
 };

--- a/src/functions/tester/mod.ts
+++ b/src/functions/tester/mod.ts
@@ -3,24 +3,9 @@ import {
   PossibleParameterKeys,
 } from "../../parameters/mod.ts";
 import { SlackFunction } from "../mod.ts";
-import type { BlockAction } from "../routers/types.ts";
 import type { FunctionRuntimeParameters } from "../types.ts";
-import {
-  CreateActionHandlerContext,
-  CreateFunctionContext,
-  SlackActionHandlerTesterFn,
-  SlackFunctionTesterFn,
-} from "./types.ts";
-
+import { CreateFunctionContext, SlackFunctionTesterFn } from "./types.ts";
 export const DEFAULT_FUNCTION_TESTER_TITLE = "Function Test Title";
-export const DEFAULT_ACTION: BlockAction = {
-  type: "button",
-  block_id: "block_id",
-  action_ts: `${new Date().getTime()}`,
-  action_id: "action_id",
-  text: { type: "plain_text", text: "duncare", emoji: false },
-  style: "danger",
-};
 
 export const SlackFunctionTester: SlackFunctionTesterFn = <
   InputParameters extends ParameterSetDefinition,
@@ -73,45 +58,6 @@ export const SlackFunctionTester: SlackFunctionTesterFn = <
           title: testFnTitle,
         },
       },
-    };
-  };
-
-  return { createContext };
-};
-
-export const SlackActionHandlerTester: SlackActionHandlerTesterFn = <
-  InputParameters extends ParameterSetDefinition,
-  OutputParameters extends ParameterSetDefinition,
-  RequiredInput extends PossibleParameterKeys<InputParameters>,
-  RequiredOutput extends PossibleParameterKeys<OutputParameters>,
->(
-  _func: SlackFunction<
-    InputParameters,
-    OutputParameters,
-    RequiredInput,
-    RequiredOutput
-  >,
-) => {
-  const createContext: CreateActionHandlerContext<
-    InputParameters,
-    RequiredInput
-  > = (
-    args,
-  ) => {
-    const DEFAULT_BODY = {
-      type: "block_actions",
-      actions: [DEFAULT_ACTION],
-    };
-
-    return {
-      inputs: (args.inputs || {}) as FunctionRuntimeParameters<
-        InputParameters,
-        RequiredInput
-      >,
-      env: args.env || {},
-      token: args.token || "slack-function-test-token",
-      action: args.action || DEFAULT_ACTION,
-      body: args.body || DEFAULT_BODY,
     };
   };
 

--- a/src/functions/tester/mod.ts
+++ b/src/functions/tester/mod.ts
@@ -3,7 +3,8 @@ import {
   PossibleParameterKeys,
 } from "../../parameters/mod.ts";
 import { SlackFunction } from "../mod.ts";
-import type { BlockAction, FunctionRuntimeParameters } from "../types.ts";
+import type { BlockAction } from "../routers/types.ts";
+import type { FunctionRuntimeParameters } from "../types.ts";
 import {
   CreateActionHandlerContext,
   CreateFunctionContext,

--- a/src/functions/tester/mod.ts
+++ b/src/functions/tester/mod.ts
@@ -3,10 +3,23 @@ import {
   PossibleParameterKeys,
 } from "../../parameters/mod.ts";
 import { SlackFunction } from "../mod.ts";
-import type { FunctionRuntimeParameters } from "../types.ts";
-import { CreateContext, SlackFunctionTesterFn } from "./types.ts";
+import type { BlockAction, FunctionRuntimeParameters } from "../types.ts";
+import {
+  CreateActionHandlerContext,
+  CreateFunctionContext,
+  SlackActionHandlerTesterFn,
+  SlackFunctionTesterFn,
+} from "./types.ts";
 
 export const DEFAULT_FUNCTION_TESTER_TITLE = "Function Test Title";
+export const DEFAULT_ACTION: BlockAction = {
+  type: "button",
+  block_id: "block_id",
+  action_ts: `${new Date().getTime()}`,
+  action_id: "action_id",
+  text: { type: "plain_text", text: "duncare", emoji: false },
+  style: "danger",
+};
 
 export const SlackFunctionTester: SlackFunctionTesterFn = <
   InputParameters extends ParameterSetDefinition,
@@ -36,7 +49,7 @@ export const SlackFunctionTester: SlackFunctionTesterFn = <
     testFnTitle = funcOrCallbackId.definition.title;
   }
 
-  const createContext: CreateContext<InputParameters, RequiredInput> = (
+  const createContext: CreateFunctionContext<InputParameters, RequiredInput> = (
     args,
   ) => {
     const ts = new Date();
@@ -59,6 +72,45 @@ export const SlackFunctionTester: SlackFunctionTesterFn = <
           title: testFnTitle,
         },
       },
+    };
+  };
+
+  return { createContext };
+};
+
+export const SlackActionHandlerTester: SlackActionHandlerTesterFn = <
+  InputParameters extends ParameterSetDefinition,
+  OutputParameters extends ParameterSetDefinition,
+  RequiredInput extends PossibleParameterKeys<InputParameters>,
+  RequiredOutput extends PossibleParameterKeys<OutputParameters>,
+>(
+  _func: SlackFunction<
+    InputParameters,
+    OutputParameters,
+    RequiredInput,
+    RequiredOutput
+  >,
+) => {
+  const createContext: CreateActionHandlerContext<
+    InputParameters,
+    RequiredInput
+  > = (
+    args,
+  ) => {
+    const DEFAULT_BODY = {
+      type: "block_actions",
+      actions: [DEFAULT_ACTION],
+    };
+
+    return {
+      inputs: (args.inputs || {}) as FunctionRuntimeParameters<
+        InputParameters,
+        RequiredInput
+      >,
+      env: args.env || {},
+      token: args.token || "slack-function-test-token",
+      action: args.action || DEFAULT_ACTION,
+      body: args.body || DEFAULT_BODY,
     };
   };
 

--- a/src/functions/tester/types.ts
+++ b/src/functions/tester/types.ts
@@ -3,7 +3,11 @@ import type {
   PossibleParameterKeys,
 } from "../../parameters/mod.ts";
 import type { SlackFunction } from "../mod.ts";
-import type { FunctionContext, FunctionRuntimeParameters } from "../types.ts";
+import type {
+  ActionContext,
+  FunctionContext,
+  FunctionRuntimeParameters,
+} from "../types.ts";
 
 export type SlackFunctionTesterArgs<
   InputParameters,
@@ -15,7 +19,7 @@ export type SlackFunctionTesterArgs<
     inputs: InputParameters;
   };
 
-export type CreateContext<
+export type CreateFunctionContext<
   InputParameters extends ParameterSetDefinition,
   RequiredInput extends PossibleParameterKeys<InputParameters>,
 > = {
@@ -32,7 +36,7 @@ export type SlackFunctionTesterResponse<
   InputParameters extends ParameterSetDefinition,
   RequiredInput extends PossibleParameterKeys<InputParameters>,
 > = {
-  createContext: CreateContext<InputParameters, RequiredInput>;
+  createContext: CreateFunctionContext<InputParameters, RequiredInput>;
 };
 
 // Slack Function Tester is overloaded to accept either a string or a SlackFunction
@@ -61,4 +65,52 @@ export type SlackFunctionTesterFn = {
       <I>(args: SlackFunctionTesterArgs<I>): FunctionContext<I>;
     };
   };
+};
+
+export type SlackActionHandlerTesterArgs<InputParameters> =
+  & Partial<
+    ActionContext<InputParameters>
+  >
+  & {
+    inputs: InputParameters;
+  };
+
+export type CreateActionHandlerContext<
+  InputParameters extends ParameterSetDefinition,
+  RequiredInput extends PossibleParameterKeys<InputParameters>,
+> = {
+  (
+    args: SlackActionHandlerTesterArgs<
+      FunctionRuntimeParameters<InputParameters, RequiredInput>
+    >,
+  ): ActionContext<
+    FunctionRuntimeParameters<InputParameters, RequiredInput>
+  >;
+};
+
+export type SlackActionHandlerTesterResponse<
+  InputParameters extends ParameterSetDefinition,
+  RequiredInput extends PossibleParameterKeys<InputParameters>,
+> = {
+  createContext: CreateActionHandlerContext<InputParameters, RequiredInput>;
+};
+
+export type SlackActionHandlerTesterFn = {
+  // Accept a Slack Function
+  <
+    InputParameters extends ParameterSetDefinition,
+    OutputParameters extends ParameterSetDefinition,
+    RequiredInput extends PossibleParameterKeys<InputParameters>,
+    RequiredOutput extends PossibleParameterKeys<OutputParameters>,
+  >(
+    func: SlackFunction<
+      InputParameters,
+      OutputParameters,
+      RequiredInput,
+      RequiredOutput
+    >,
+  ): SlackActionHandlerTesterResponse<
+    InputParameters,
+    RequiredInput
+  >;
 };

--- a/src/functions/tester/types.ts
+++ b/src/functions/tester/types.ts
@@ -4,7 +4,6 @@ import type {
 } from "../../parameters/mod.ts";
 import type { SlackFunction } from "../mod.ts";
 import type { FunctionContext, FunctionRuntimeParameters } from "../types.ts";
-import type { ActionContext } from "../routers/types.ts";
 
 export type SlackFunctionTesterArgs<
   InputParameters,
@@ -62,52 +61,4 @@ export type SlackFunctionTesterFn = {
       <I>(args: SlackFunctionTesterArgs<I>): FunctionContext<I>;
     };
   };
-};
-
-export type SlackActionHandlerTesterArgs<InputParameters> =
-  & Partial<
-    ActionContext<InputParameters>
-  >
-  & {
-    inputs: InputParameters;
-  };
-
-export type CreateActionHandlerContext<
-  InputParameters extends ParameterSetDefinition,
-  RequiredInput extends PossibleParameterKeys<InputParameters>,
-> = {
-  (
-    args: SlackActionHandlerTesterArgs<
-      FunctionRuntimeParameters<InputParameters, RequiredInput>
-    >,
-  ): ActionContext<
-    FunctionRuntimeParameters<InputParameters, RequiredInput>
-  >;
-};
-
-export type SlackActionHandlerTesterResponse<
-  InputParameters extends ParameterSetDefinition,
-  RequiredInput extends PossibleParameterKeys<InputParameters>,
-> = {
-  createContext: CreateActionHandlerContext<InputParameters, RequiredInput>;
-};
-
-export type SlackActionHandlerTesterFn = {
-  // Accept a Slack Function
-  <
-    InputParameters extends ParameterSetDefinition,
-    OutputParameters extends ParameterSetDefinition,
-    RequiredInput extends PossibleParameterKeys<InputParameters>,
-    RequiredOutput extends PossibleParameterKeys<OutputParameters>,
-  >(
-    func: SlackFunction<
-      InputParameters,
-      OutputParameters,
-      RequiredInput,
-      RequiredOutput
-    >,
-  ): SlackActionHandlerTesterResponse<
-    InputParameters,
-    RequiredInput
-  >;
 };

--- a/src/functions/tester/types.ts
+++ b/src/functions/tester/types.ts
@@ -3,11 +3,8 @@ import type {
   PossibleParameterKeys,
 } from "../../parameters/mod.ts";
 import type { SlackFunction } from "../mod.ts";
-import type {
-  ActionContext,
-  FunctionContext,
-  FunctionRuntimeParameters,
-} from "../types.ts";
+import type { FunctionContext, FunctionRuntimeParameters } from "../types.ts";
+import type { ActionContext } from "../routers/types.ts";
 
 export type SlackFunctionTesterArgs<
   InputParameters,

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -13,11 +13,7 @@ import type SchemaTypes from "../schema/schema_types.ts";
 import type SlackSchemaTypes from "../schema/slack/schema_types.ts";
 import { SlackManifest } from "../manifest.ts";
 
-export type {
-  ActionContext,
-  BlockAction,
-  BlockActionHandler,
-} from "./routers/types.ts";
+export type { BlockActionHandler } from "./routers/types.ts";
 
 export type FunctionInvocationBody = {
   "team_id": string;

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -13,6 +13,12 @@ import type SchemaTypes from "../schema/schema_types.ts";
 import type SlackSchemaTypes from "../schema/slack/schema_types.ts";
 import { SlackManifest } from "../manifest.ts";
 
+export type {
+  ActionContext,
+  BlockAction,
+  BlockActionHandler,
+} from "./routers/types.ts";
+
 export type FunctionInvocationBody = {
   "team_id": string;
   "api_app_id": string;

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,5 +1,6 @@
 export { Manifest } from "./manifest.ts";
 export { DefineFunction } from "./functions/mod.ts";
+export { BlockActionsRouter } from "./functions/routers/mod.ts";
 export { DefineWorkflow } from "./workflows/mod.ts";
 export { DefineType } from "./types/mod.ts";
 export { DefineOAuth2Provider } from "./providers/oauth2/mod.ts";

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ import { OAuth2ProviderTypeValues } from "./schema/providers/oauth2/types.ts";
 
 export type {
   BaseSlackFunctionHandler,
+  BlockActionHandler,
   FunctionHandler, // Deprecated
   SlackFunctionHandler,
 } from "./functions/types.ts";


### PR DESCRIPTION
###  Summary

Mostly following the template experimented with here: https://corp.quip.com/FF6hAO3C4UbL/Function-Interactivity-Examples

Pair this up with the PR on internal GitHub for the app consuming this: https://slack-github.com/bharris/interactive-approval/pull/1

Also loosely based on[ @selfcontained's `bradh-fn-interactivity-handlers-duex` branch of deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime/tree/bradh-fn-interactivity-handlers-duex).

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
