### PR TITLE
Enable codecov coverage reporting.

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -21,3 +21,11 @@ jobs:
 
       - name: Run tests
         run: deno task test
+
+      - name: Generate CodeCov-friendly coverage report
+        run: deno task coverage --lcov --output=codecov.lcov
+
+      - name: Upload coverage to CodeCov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          file: ./codecov.lcov

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,12 +1,14 @@
 {
   "fmt": {
     "files": {
-      "include": ["src"]
+      "include": ["src"],
+      "exclude": ["src/schema/slack/functions/_scripts/functions.json"]
     }
   },
   "lint": {
     "files": {
-      "include": ["src"]
+      "include": ["src"],
+      "exclude": ["src/schema/slack/functions/_scripts/functions.json"]
     }
   },
   "tasks": {


### PR DESCRIPTION
 Ignore functions.json schema from linting or checking.