### PR TITLE
Initial implementation of the slack logger

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,37 +8,37 @@ enum LogLevel {
 }
 
 export function debug<T>(
-  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+  msg: (T extends (...args: unknown[]) => unknown ? never : T) | (() => T),
 ): string {
   return write(msg, LogLevel.DEBUG);
 }
 
 export function info<T>(
-  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+  msg: (T extends (...args: unknown[]) => unknown ? never : T) | (() => T),
 ): string {
   return write(msg, LogLevel.INFO);
 }
 
 export function warn<T>(
-  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+  msg: (T extends (...args: unknown[]) => unknown ? never : T) | (() => T),
 ): string {
   return write(msg, LogLevel.WARN);
 }
 
 export function error<T>(
-  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+  msg: (T extends (...args: unknown[]) => unknown ? never : T) | (() => T),
 ): string {
   return write(msg, LogLevel.ERROR);
 }
 
 export function fatal<T>(
-  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+  msg: (T extends (...args: unknown[]) => unknown ? never : T) | (() => T),
 ): string {
   return write(msg, LogLevel.FATAL);
 }
 
 function write<T>(
-  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+  msg: (T extends (...args: unknown[]) => unknown ? never : T) | (() => T),
   level: LogLevel,
 ): string {
   let res: T | undefined;
@@ -51,7 +51,7 @@ function write<T>(
     logMessage = toString(msg);
   }
 
-  let formattedLog =
+  const formattedLog =
     `{"loggerName":"slack","msg":"${logMessage}","level":${level},"datetime":"${
       new Date().toISOString()
     }"}`;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,80 @@
+enum LogLevel {
+  NONE = 0,
+  DEBUG = 10,
+  INFO = 20,
+  WARN = 30,
+  ERROR = 40,
+  FATAL = 50,
+}
+
+export function debug<T>(
+  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+): string {
+  return write(msg, LogLevel.DEBUG);
+}
+
+export function info<T>(
+  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+): string {
+  return write(msg, LogLevel.INFO);
+}
+
+export function warn<T>(
+  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+): string {
+  return write(msg, LogLevel.WARN);
+}
+
+export function error<T>(
+  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+): string {
+  return write(msg, LogLevel.ERROR);
+}
+
+export function fatal<T>(
+  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+): string {
+  return write(msg, LogLevel.FATAL);
+}
+
+function write<T>(
+  msg: (T extends (...args: any[]) => any ? never : T) | (() => T),
+  level: LogLevel,
+): string {
+  let res: T | undefined;
+  let logMessage: string;
+
+  if (msg instanceof Function) {
+    res = msg();
+    logMessage = toString(res);
+  } else {
+    logMessage = toString(msg);
+  }
+
+  let formattedLog =
+    `{"loggerName":"slack","msg":"${logMessage}","level":${level},"datetime":"${
+      new Date().toISOString()
+    }"}`;
+
+  console.log(formattedLog);
+
+  return formattedLog;
+}
+
+function toString(obj: unknown): string {
+  if (typeof obj === "string") {
+    return obj;
+  } else if (
+    obj === null ||
+    typeof obj === "number" ||
+    typeof obj === "bigint" ||
+    typeof obj === "boolean" ||
+    typeof obj === "undefined" ||
+    typeof obj === "symbol"
+  ) {
+    return String(obj);
+  } else if (typeof obj === "object") {
+    return JSON.stringify(obj);
+  }
+  return "undefined";
+}

--- a/src/logger_test.ts
+++ b/src/logger_test.ts
@@ -1,0 +1,105 @@
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.148.0/testing/asserts.ts";
+
+import * as logger from "./logger.ts";
+
+const regex =
+  /^{\"loggerName\":\"slack\",\"msg\":\"(?<msg>.*)\",\"level\":(?<level>10|20|30|40|50),\"datetime\":\"(?<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)\"}$/;
+
+Deno.test("Test logging with string", () => {
+  const msg = "This is a string";
+  const res = logger.info(msg);
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["msg"], msg);
+});
+
+Deno.test("Test logging with int", () => {
+  const msg = 15;
+  const res = logger.info(msg);
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["msg"], "15");
+});
+
+Deno.test("Test logging with object", () => {
+  const msg = { "test": 15 };
+  const res = logger.info(msg);
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["msg"], `{"test":15}`);
+});
+
+Deno.test("Test debug logging", () => {
+  const msg = "Test";
+  const res = logger.debug(msg);
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["level"], "10");
+});
+
+Deno.test("Test info logging", () => {
+  const msg = "Test";
+  const res = logger.info(msg);
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["level"], "20");
+});
+
+Deno.test("Test warn logging", () => {
+  const msg = "Test";
+  const res = logger.warn(msg);
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["level"], "30");
+});
+
+Deno.test("Test error logging", () => {
+  const msg = "Test";
+  const res = logger.error(msg);
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["level"], "40");
+});
+
+Deno.test("Test fatal logging", () => {
+  const msg = "Test";
+  const res = logger.fatal(msg);
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["level"], "50");
+});

--- a/src/logger_test.ts
+++ b/src/logger_test.ts
@@ -20,6 +20,20 @@ Deno.test("Test logging with string", () => {
   assertEquals(match.groups["msg"], msg);
 });
 
+Deno.test("Test logging with function", () => {
+  const msg = "This is a string";
+  const res = logger.info(() => {
+    return msg;
+  });
+
+  const match = res.match(regex);
+
+  assertExists(match);
+  assertExists(match.groups);
+
+  assertEquals(match.groups["msg"], msg);
+});
+
 Deno.test("Test logging with int", () => {
   const msg = 15;
   const res = logger.info(msg);


### PR DESCRIPTION
###  Summary
Currently stdout/stderr of AWS lambdas is being parsed by webapp at the end of execution for specific strings in order to generate structured/filterable/searchable logs (`apps.activities.list`). 

This helper is being provided to avoid having Slack app devs bother with the intricate format expectations of their logging.


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
