### PR TITLE
Initial support for `user_context` and `interactivity` types

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -13,6 +13,10 @@ import {
 import type SchemaTypes from "../schema/schema_types.ts";
 import type SlackSchemaTypes from "../schema/slack/schema_types.ts";
 import { SlackManifest } from "../manifest/mod.ts";
+import {
+  InteractivityParameterDefinition,
+  UserContextParameterDefinition,
+} from "../schema/slack/schema_types.ts";
 
 export type { BlockActionHandler } from "./routers/types.ts";
 
@@ -52,6 +56,14 @@ type FunctionInputRuntimeType<Param extends ParameterDefinition> =
       ? Param extends TypedObjectParameterDefinition
         ? TypedObjectFunctionInputRuntimeType<Param>
       : UnknownRuntimeType
+    : Param["type"] extends typeof SlackSchemaTypes.interactivity
+      ? TypedObjectFunctionInputRuntimeType<
+        typeof InteractivityParameterDefinition
+      >
+    : Param["type"] extends typeof SlackSchemaTypes.user_context
+      ? TypedObjectFunctionInputRuntimeType<
+        typeof UserContextParameterDefinition
+      >
     : Param["type"] extends
       | typeof SlackSchemaTypes.user_id
       | typeof SlackSchemaTypes.usergroup_id

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -8,6 +8,10 @@ import type {
 import { ParamReference } from "./param.ts";
 import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
 import SchemaTypes from "../schema/schema_types.ts";
+import SlackTypes, {
+  InteractivityParameterDefinition,
+  UserContextParameterDefinition,
+} from "../schema/slack/schema_types.ts";
 
 export type ParameterDefinition = TypedParameterDefinition;
 
@@ -35,6 +39,10 @@ export type ParameterVariableType<Def extends ParameterDefinition> = Def extends
     ? ObjectParameterVariableType<Def>
   : Def extends UntypedObjectParameterDefinition
     ? UntypedObjectParameterVariableType
+  : Def["type"] extends typeof SlackTypes["interactivity"]
+    ? ObjectParameterVariableType<typeof InteractivityParameterDefinition>
+  : Def["type"] extends typeof SlackTypes["user_context"]
+    ? ObjectParameterVariableType<typeof UserContextParameterDefinition>
   : SingleParameterVariable;
 
 // deno-lint-ignore ban-types
@@ -85,6 +93,18 @@ export const ParameterVariable = <P extends ParameterDefinition>(
     } else {
       param = CreateUntypedObjectParameterVariable(namespace, paramName);
     }
+  } else if (definition.type === SlackTypes.interactivity) {
+    param = CreateTypedObjectParameterVariable(
+      namespace,
+      paramName,
+      InteractivityParameterDefinition,
+    ) as ParameterVariableType<P>;
+  } else if (definition.type === SlackTypes.user_context) {
+    param = CreateTypedObjectParameterVariable(
+      namespace,
+      paramName,
+      UserContextParameterDefinition,
+    ) as ParameterVariableType<P>;
   } else {
     param = CreateSingleParameterVariable(
       namespace,

--- a/src/schema/slack/schema_types.ts
+++ b/src/schema/slack/schema_types.ts
@@ -5,6 +5,7 @@ const SlackTypes = {
   timestamp: "slack#/types/timestamp",
   blocks: "slack#/types/blocks",
   oauth2: "slack#/types/credential/oauth2",
+  user_context: "slack#/types/user_context",
 } as const;
 
 export default SlackTypes;

--- a/src/schema/slack/schema_types.ts
+++ b/src/schema/slack/schema_types.ts
@@ -1,3 +1,5 @@
+import SchemaTypes from "../schema_types.ts";
+
 const SlackTypes = {
   user_id: "slack#/types/user_id",
   channel_id: "slack#/types/channel_id",
@@ -6,6 +8,31 @@ const SlackTypes = {
   blocks: "slack#/types/blocks",
   oauth2: "slack#/types/credential/oauth2",
   user_context: "slack#/types/user_context",
+  interactivity: "slack#/types/interactivity",
+} as const;
+
+export const InteractivityParameterDefinition = {
+  type: SchemaTypes.object,
+  properties: {
+    interactivity_pointer: {
+      type: SchemaTypes.string,
+    },
+    interactor: {
+      type: SlackTypes.user_context,
+    },
+  },
+} as const;
+
+export const UserContextParameterDefinition = {
+  type: SchemaTypes.object,
+  properties: {
+    id: {
+      type: SlackTypes.user_id,
+    },
+    secret: {
+      type: SchemaTypes.string,
+    },
+  },
 } as const;
 
 export default SlackTypes;

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -125,14 +125,8 @@ Deno.test("Workflows properly treats interactivity and user context types", () =
         interactivity: {
           type: SlackTypes.interactivity,
         },
-        somethingElse: {
-          type: "object",
-          properties: {
-            nestedObject: {
-              type: "object",
-              properties: { finalString: { type: "string" } },
-            },
-          },
+        user: {
+          type: SlackTypes.user_context,
         },
       },
       required: ["interactivity"],
@@ -161,5 +155,17 @@ Deno.test("Workflows properly treats interactivity and user context types", () =
   assertEquals(
     `${step1.outputs.interactivity.interactor.secret}`,
     `{{steps.0.interactivity.interactor.secret}}`,
+  );
+  assertEquals(
+    `${step1.outputs.user}`,
+    `{{steps.0.user}}`,
+  );
+  assertEquals(
+    `${step1.outputs.user?.id}`,
+    `{{steps.0.user.id}}`,
+  );
+  assertEquals(
+    `${step1.outputs.user?.secret}`,
+    `{{steps.0.user.secret}}`,
   );
 });

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "../dev_deps.ts";
 import { DefineWorkflow } from "./mod.ts";
 import { DefineFunction } from "../mod.ts";
+import SlackTypes from "../schema/slack/schema_types.ts";
 
 Deno.test("WorkflowStep export input values", () => {
   const TestFunction = DefineFunction({
@@ -111,5 +112,54 @@ Deno.test("WorkflowStep export input values", () => {
   assertEquals(
     `${step3Inputs.message}`,
     "Channel Created <#{{steps.1.channel_id}}>",
+  );
+});
+
+Deno.test("Workflows properly treats interactivity and user context types", () => {
+  const TestFunction = DefineFunction({
+    source_file: "./test.ts",
+    callback_id: "test",
+    title: "Test",
+    output_parameters: {
+      properties: {
+        interactivity: {
+          type: SlackTypes.interactivity,
+        },
+        somethingElse: {
+          type: "object",
+          properties: {
+            nestedObject: {
+              type: "object",
+              properties: { finalString: { type: "string" } },
+            },
+          },
+        },
+      },
+      required: ["interactivity"],
+    },
+  });
+
+  const TestWorkflow = DefineWorkflow({
+    callback_id: "test",
+    title: "Test",
+  });
+
+  const step1 = TestWorkflow.addStep(TestFunction, {});
+
+  assertEquals(
+    `${step1.outputs.interactivity}`,
+    `{{steps.0.interactivity}}`,
+  );
+  assertEquals(
+    `${step1.outputs.interactivity.interactivity_pointer}`,
+    `{{steps.0.interactivity.interactivity_pointer}}`,
+  );
+  assertEquals(
+    `${step1.outputs.interactivity.interactor.id}`,
+    `{{steps.0.interactivity.interactor.id}}`,
+  );
+  assertEquals(
+    `${step1.outputs.interactivity.interactor.secret}`,
+    `{{steps.0.interactivity.interactor.secret}}`,
   );
 });


### PR DESCRIPTION
## Summary
Adding crude support for the new `user_context` and `interactivity` Slack types

### Description
Adding `user_context` and `interactivity` to our list of `SlackTypes`.

### Testing
Set `user_context` and `interactivity` as the types for function and workflow input/output parameters and verify that they're appropriately treated in the output of `hermes manifest`.