### PR TITLE
Adding some typing for block_actions body

### DIFF
--- a/src/functions/routers/action_router.ts
+++ b/src/functions/routers/action_router.ts
@@ -5,12 +5,12 @@ import {
 import { SlackFunction } from "../mod.ts";
 import { FunctionDefinitionArgs } from "../types.ts";
 import type {
-  BlockAction,
   BlockActionConstraint,
   BlockActionConstraintField,
   BlockActionConstraintObject,
   BlockActionHandler,
 } from "./types.ts";
+import { BlockAction } from "./block_actions_types.ts";
 
 /**
  * Define an actions "router" and its input and output parameters for use in a Slack application. The ActionsRouter will route incoming action events to action-specific handlers.

--- a/src/functions/routers/action_router_test.ts
+++ b/src/functions/routers/action_router_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertExists, assertMatch } from "../../dev_deps.ts";
 import { BlockActionsRouter } from "./action_router.ts";
-import type { ActionContext, BlockAction } from "./types.ts";
+import type { ActionContext } from "./types.ts";
+import type { BlockAction } from "./block_actions_types.ts";
 import type { FunctionRuntimeParameters } from "../types.ts";
 import type {
   ParameterSetDefinition,
@@ -99,6 +100,26 @@ const SlackActionHandlerTester: SlackActionHandlerTesterFn = <
         function: { callback_id: "456" },
         inputs,
       },
+      interactivity: {
+        interactor: {
+          secret: "shhhh",
+          id: "123",
+        },
+        interactivity_pointer: "123.asdf",
+      },
+      user: {
+        id: "123",
+        name: "asdf",
+        team_id: "123",
+      },
+      team: {
+        id: "123",
+        domain: "asdf",
+      },
+      api_app_id: "123",
+      token: "123",
+      trigger_id: "123",
+      response_url: "asdf",
     };
 
     return {

--- a/src/functions/routers/block_actions_types.ts
+++ b/src/functions/routers/block_actions_types.ts
@@ -13,8 +13,6 @@ export type BlockActionsBody = {
   team: {
     id: string;
     domain: string;
-    enterprise_id?: string;
-    enterprise_name?: string;
   };
   enterprise?: {
     id: string;

--- a/src/functions/routers/block_actions_types.ts
+++ b/src/functions/routers/block_actions_types.ts
@@ -1,0 +1,40 @@
+// This is currently a pretty light type of a block_actions payload that we can fill out
+// once we have a way to share some of these payload types across our different libraries better
+export type BlockActionsBody = {
+  // type: "block_actions";
+  user: {
+    id: string;
+    name: string;
+    team_id: string;
+  };
+  api_app_id: string;
+  token: string;
+  trigger_id: string;
+  team: {
+    id: string;
+    domain: string;
+    enterprise_id?: string;
+    enterprise_name?: string;
+  };
+  enterprise?: {
+    id: string;
+    name: string;
+  } | null;
+  is_enterprise_install?: boolean;
+  channel?: {
+    id: string;
+    name: string;
+  };
+  actions: BlockAction[];
+  response_url: string;
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
+};
+
+export type BlockAction = {
+  type: string;
+  block_id: string;
+  action_id: string;
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
+};

--- a/src/functions/routers/types.ts
+++ b/src/functions/routers/types.ts
@@ -42,11 +42,13 @@ type FunctionData<InputParameters extends FunctionParameters> = {
 };
 
 type Interactivity = {
-  interactor: {
-    secret: string;
-    id: string;
-  };
+  interactor: UserContext;
   interactivity_pointer: string;
+};
+
+type UserContext = {
+  secret: string;
+  id: string;
 };
 
 export type BlockActionConstraint =

--- a/src/functions/routers/types.ts
+++ b/src/functions/routers/types.ts
@@ -4,6 +4,7 @@ import {
   FunctionParameters,
   FunctionRuntimeParameters,
 } from "../types.ts";
+import { BlockAction, BlockActionsBody } from "./block_actions_types.ts";
 
 export type BlockActionHandler<Definition> = Definition extends
   FunctionDefinitionArgs<infer I, infer O, infer RI, infer RO> ? {
@@ -23,15 +24,13 @@ type ActionSpecificContext<InputParameters extends FunctionParameters> = {
   action: BlockAction;
 };
 
-// TODO: all below stolen from deno-slack-runtime, need to centralize these somewhere
 export type BlockActionInvocationBody<
   InputParameters extends FunctionParameters,
-> = {
-  type: string;
-  actions: BlockAction[];
+> = BlockActionsBody & FunctionInteractivity<InputParameters>;
+
+type FunctionInteractivity<InputParameters extends FunctionParameters> = {
   function_data: FunctionData<InputParameters>;
-  // deno-lint-ignore no-explicit-any
-  [key: string]: any;
+  interactivity: Interactivity;
 };
 
 type FunctionData<InputParameters extends FunctionParameters> = {
@@ -42,12 +41,12 @@ type FunctionData<InputParameters extends FunctionParameters> = {
   inputs: InputParameters;
 };
 
-export type BlockAction = {
-  type: string;
-  block_id: string;
-  action_id: string;
-  // deno-lint-ignore no-explicit-any
-  [key: string]: any;
+type Interactivity = {
+  interactor: {
+    secret: string;
+    id: string;
+  };
+  interactivity_pointer: string;
 };
 
 export type BlockActionConstraint =


### PR DESCRIPTION
###  Summary

This adds a little bit more typing for the `body` of the BlockActionsRouter handlers. I've added the new `interactivity` portion of the payload, and then flushed out some of the other more common and simple properties for now, such as `user` and `team`, as well as other portions of the payload. Ideally we can come up with a strategy to centralize these payload types to share across our libraries.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
