### PR TITLE
Use Custom Types for `user_context` and `interactivity` types

### DIFF
--- a/src/functions/slack_function_handler_type_test.ts
+++ b/src/functions/slack_function_handler_type_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "../dev_deps.ts";
+import { assertExists } from "../dev_deps.ts";
 import { assertEqualsTypedValues } from "../test_utils.ts";
 import { SlackFunctionTester } from "./tester/mod.ts";
 import { DefineFunction } from "./mod.ts";

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -13,10 +13,6 @@ import {
 import type SchemaTypes from "../schema/schema_types.ts";
 import type SlackSchemaTypes from "../schema/slack/schema_types.ts";
 import { SlackManifest } from "../manifest/mod.ts";
-import {
-  InteractivityParameterDefinition,
-  UserContextParameterDefinition,
-} from "../schema/slack/schema_types.ts";
 
 export type { BlockActionHandler } from "./routers/types.ts";
 
@@ -56,14 +52,6 @@ type FunctionInputRuntimeType<Param extends ParameterDefinition> =
       ? Param extends TypedObjectParameterDefinition
         ? TypedObjectFunctionInputRuntimeType<Param>
       : UnknownRuntimeType
-    : Param["type"] extends typeof SlackSchemaTypes.interactivity
-      ? TypedObjectFunctionInputRuntimeType<
-        typeof InteractivityParameterDefinition
-      >
-    : Param["type"] extends typeof SlackSchemaTypes.user_context
-      ? TypedObjectFunctionInputRuntimeType<
-        typeof UserContextParameterDefinition
-      >
     : Param["type"] extends
       | typeof SlackSchemaTypes.user_id
       | typeof SlackSchemaTypes.usergroup_id

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -8,10 +8,6 @@ import type {
 import { ParamReference } from "./param.ts";
 import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
 import SchemaTypes from "../schema/schema_types.ts";
-import SlackTypes, {
-  InteractivityParameterDefinition,
-  UserContextParameterDefinition,
-} from "../schema/slack/schema_types.ts";
 
 export type ParameterDefinition = TypedParameterDefinition;
 
@@ -39,10 +35,6 @@ export type ParameterVariableType<Def extends ParameterDefinition> = Def extends
     ? ObjectParameterVariableType<Def>
   : Def extends UntypedObjectParameterDefinition
     ? UntypedObjectParameterVariableType
-  : Def["type"] extends typeof SlackTypes["interactivity"]
-    ? ObjectParameterVariableType<typeof InteractivityParameterDefinition>
-  : Def["type"] extends typeof SlackTypes["user_context"]
-    ? ObjectParameterVariableType<typeof UserContextParameterDefinition>
   : SingleParameterVariable;
 
 // deno-lint-ignore ban-types
@@ -93,18 +85,6 @@ export const ParameterVariable = <P extends ParameterDefinition>(
     } else {
       param = CreateUntypedObjectParameterVariable(namespace, paramName);
     }
-  } else if (definition.type === SlackTypes.interactivity) {
-    param = CreateTypedObjectParameterVariable(
-      namespace,
-      paramName,
-      InteractivityParameterDefinition,
-    ) as ParameterVariableType<P>;
-  } else if (definition.type === SlackTypes.user_context) {
-    param = CreateTypedObjectParameterVariable(
-      namespace,
-      paramName,
-      UserContextParameterDefinition,
-    ) as ParameterVariableType<P>;
   } else {
     param = CreateSingleParameterVariable(
       namespace,

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -1,5 +1,5 @@
 import SchemaTypes from "../schema/schema_types.ts";
-import SlackTypes from "../schema/slack/schema_types.ts";
+import { SlackTypes } from "../schema/slack/schema_types.ts";
 import { ICustomType } from "../types/types.ts";
 
 export type PrimitiveParameterDefinition =

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -1,5 +1,5 @@
 import SchemaTypes from "../schema/schema_types.ts";
-import { SlackTypes } from "../schema/slack/schema_types.ts";
+import SlackTypes from "../schema/slack/types/mod.ts";
 import { ICustomType } from "../types/types.ts";
 
 export type PrimitiveParameterDefinition =

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -1,5 +1,5 @@
 import SchemaTypes from "../schema/schema_types.ts";
-import SlackTypes from "../schema/slack/types/mod.ts";
+import { SlackPrimitiveTypes } from "../schema/slack/types/mod.ts";
 import { ICustomType } from "../types/types.ts";
 
 export type PrimitiveParameterDefinition =
@@ -98,7 +98,7 @@ type NumberParameterDefinition = BaseParameterDefinition<number> & {
 };
 
 export type OAuth2ParameterDefinition = BaseParameterDefinition<string> & {
-  type: typeof SlackTypes.oauth2;
+  type: typeof SlackPrimitiveTypes.oauth2;
   oauth2_provider_key: string;
 };
 

--- a/src/schema/slack/schema_types.ts
+++ b/src/schema/slack/schema_types.ts
@@ -1,4 +1,4 @@
-import SlackTypes from "./types/mod.ts";
-import SlackCustomTypes from "./types/custom/mod.ts";
+import { SlackPrimitiveTypes } from "./types/mod.ts";
+import { CustomSlackTypes } from "./types/custom/mod.ts";
 
-export default { ...SlackTypes, ...SlackCustomTypes };
+export default { ...SlackPrimitiveTypes, ...CustomSlackTypes };

--- a/src/schema/slack/schema_types.ts
+++ b/src/schema/slack/schema_types.ts
@@ -1,29 +1,17 @@
 import SchemaTypes from "../schema_types.ts";
+import { DefineType } from "../../types/mod.ts";
 
-const SlackTypes = {
+export const SlackTypes = {
   user_id: "slack#/types/user_id",
   channel_id: "slack#/types/channel_id",
   usergroup_id: "slack#/types/usergroup_id",
   timestamp: "slack#/types/timestamp",
   blocks: "slack#/types/blocks",
   oauth2: "slack#/types/credential/oauth2",
-  user_context: "slack#/types/user_context",
-  interactivity: "slack#/types/interactivity",
 } as const;
 
-export const InteractivityParameterDefinition = {
-  type: SchemaTypes.object,
-  properties: {
-    interactivity_pointer: {
-      type: SchemaTypes.string,
-    },
-    interactor: {
-      type: SlackTypes.user_context,
-    },
-  },
-} as const;
-
-export const UserContextParameterDefinition = {
+const UserContextType = DefineType({
+  name: "User Context",
   type: SchemaTypes.object,
   properties: {
     id: {
@@ -33,6 +21,24 @@ export const UserContextParameterDefinition = {
       type: SchemaTypes.string,
     },
   },
-} as const;
+});
 
-export default SlackTypes;
+const InteractivityType = DefineType({
+  name: "User Context",
+  type: SchemaTypes.object,
+  properties: {
+    interactivity_pointer: {
+      type: SchemaTypes.string,
+    },
+    interactor: {
+      type: UserContextType,
+    },
+  },
+});
+
+export const SlackCustomTypes = {
+  interactivity: InteractivityType,
+  user_context: UserContextType,
+};
+
+export default { ...SlackTypes, ...SlackCustomTypes };

--- a/src/schema/slack/schema_types.ts
+++ b/src/schema/slack/schema_types.ts
@@ -1,44 +1,4 @@
-import SchemaTypes from "../schema_types.ts";
-import { DefineType } from "../../types/mod.ts";
-
-export const SlackTypes = {
-  user_id: "slack#/types/user_id",
-  channel_id: "slack#/types/channel_id",
-  usergroup_id: "slack#/types/usergroup_id",
-  timestamp: "slack#/types/timestamp",
-  blocks: "slack#/types/blocks",
-  oauth2: "slack#/types/credential/oauth2",
-} as const;
-
-const UserContextType = DefineType({
-  name: "User Context",
-  type: SchemaTypes.object,
-  properties: {
-    id: {
-      type: SlackTypes.user_id,
-    },
-    secret: {
-      type: SchemaTypes.string,
-    },
-  },
-});
-
-const InteractivityType = DefineType({
-  name: "User Context",
-  type: SchemaTypes.object,
-  properties: {
-    interactivity_pointer: {
-      type: SchemaTypes.string,
-    },
-    interactor: {
-      type: UserContextType,
-    },
-  },
-});
-
-export const SlackCustomTypes = {
-  interactivity: InteractivityType,
-  user_context: UserContextType,
-};
+import SlackTypes from "./types/mod.ts";
+import SlackCustomTypes from "./types/custom/mod.ts";
 
 export default { ...SlackTypes, ...SlackCustomTypes };

--- a/src/schema/slack/types/custom/interactivity.ts
+++ b/src/schema/slack/types/custom/interactivity.ts
@@ -1,0 +1,18 @@
+import SchemaTypes from "../../../schema_types.ts";
+import { DefineType } from "../../../../types/mod.ts";
+import UserContextType from "./user_context.ts";
+
+const InteractivityType = DefineType({
+  name: "User Context",
+  type: SchemaTypes.object,
+  properties: {
+    interactivity_pointer: {
+      type: SchemaTypes.string,
+    },
+    interactor: {
+      type: UserContextType,
+    },
+  },
+});
+
+export default InteractivityType;

--- a/src/schema/slack/types/custom/interactivity.ts
+++ b/src/schema/slack/types/custom/interactivity.ts
@@ -1,6 +1,6 @@
 import SchemaTypes from "../../../schema_types.ts";
 import { DefineType } from "../../../../types/mod.ts";
-import UserContextType from "./user_context.ts";
+import { UserContextType } from "./user_context.ts";
 
 const InteractivityType = DefineType({
   name: "User Context",
@@ -15,4 +15,4 @@ const InteractivityType = DefineType({
   },
 });
 
-export default InteractivityType;
+export { InteractivityType };

--- a/src/schema/slack/types/custom/mod.ts
+++ b/src/schema/slack/types/custom/mod.ts
@@ -1,9 +1,9 @@
-import InteractivityType from "./interactivity.ts";
-import UserContextType from "./user_context.ts";
+import { InteractivityType } from "./interactivity.ts";
+import { UserContextType } from "./user_context.ts";
 
 const CustomSlackTypes = {
   interactivity: InteractivityType,
   user_context: UserContextType,
 };
 
-export default CustomSlackTypes;
+export { CustomSlackTypes };

--- a/src/schema/slack/types/custom/mod.ts
+++ b/src/schema/slack/types/custom/mod.ts
@@ -1,0 +1,9 @@
+import InteractivityType from "./interactivity.ts";
+import UserContextType from "./user_context.ts";
+
+const CustomSlackTypes = {
+  interactivity: InteractivityType,
+  user_context: UserContextType,
+};
+
+export default CustomSlackTypes;

--- a/src/schema/slack/types/custom/user_context.ts
+++ b/src/schema/slack/types/custom/user_context.ts
@@ -1,0 +1,18 @@
+import SchemaTypes from "../../../schema_types.ts";
+import SlackTypes from "../../types/mod.ts";
+import { DefineType } from "../../../../types/mod.ts";
+
+const UserContextType = DefineType({
+  name: "User Context",
+  type: SchemaTypes.object,
+  properties: {
+    id: {
+      type: SlackTypes.user_id,
+    },
+    secret: {
+      type: SchemaTypes.string,
+    },
+  },
+});
+
+export default UserContextType;

--- a/src/schema/slack/types/custom/user_context.ts
+++ b/src/schema/slack/types/custom/user_context.ts
@@ -1,5 +1,5 @@
 import SchemaTypes from "../../../schema_types.ts";
-import SlackTypes from "../../types/mod.ts";
+import { SlackPrimitiveTypes } from "../../types/mod.ts";
 import { DefineType } from "../../../../types/mod.ts";
 
 const UserContextType = DefineType({
@@ -7,7 +7,7 @@ const UserContextType = DefineType({
   type: SchemaTypes.object,
   properties: {
     id: {
-      type: SlackTypes.user_id,
+      type: SlackPrimitiveTypes.user_id,
     },
     secret: {
       type: SchemaTypes.string,
@@ -15,4 +15,4 @@ const UserContextType = DefineType({
   },
 });
 
-export default UserContextType;
+export { UserContextType };

--- a/src/schema/slack/types/mod.ts
+++ b/src/schema/slack/types/mod.ts
@@ -1,4 +1,4 @@
-const SlackTypes = {
+const SlackPrimitiveTypes = {
   user_id: "slack#/types/user_id",
   channel_id: "slack#/types/channel_id",
   usergroup_id: "slack#/types/usergroup_id",
@@ -7,4 +7,4 @@ const SlackTypes = {
   oauth2: "slack#/types/credential/oauth2",
 } as const;
 
-export default SlackTypes;
+export { SlackPrimitiveTypes };

--- a/src/schema/slack/types/mod.ts
+++ b/src/schema/slack/types/mod.ts
@@ -1,0 +1,10 @@
+const SlackTypes = {
+  user_id: "slack#/types/user_id",
+  channel_id: "slack#/types/channel_id",
+  usergroup_id: "slack#/types/usergroup_id",
+  timestamp: "slack#/types/timestamp",
+  blocks: "slack#/types/blocks",
+  oauth2: "slack#/types/credential/oauth2",
+} as const;
+
+export default SlackTypes;

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -1,0 +1,12 @@
+import { assertEquals } from "./dev_deps.ts";
+
+// deno-lint-ignore ban-types
+type IsAny<T> = unknown extends T ? T extends {} ? T : never : never;
+type NotAny<T> = T extends IsAny<T> ? never : T;
+
+/** @description Prevents a value of type `any` from being passed into `assertEquals` */
+export const assertEqualsTypedValues = <T>(
+  actual: NotAny<T>,
+  expected: NotAny<T>,
+  msg?: string,
+): void => assertEquals<T>(actual, expected, msg);


### PR DESCRIPTION
###  Summary

This uses Custom Slack Types instead of the hardcoded checks!


#### Testing
Using `user_context` and `interactivity` as function input/output parameters within a workflow should continue to work and not change

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
