### PR TITLE
Default tokenManagementEnabled to false for runOnSlack apps

### DIFF
--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -214,6 +214,38 @@ Deno.test("Manifest() properly converts callback_id to proper key", () => {
   assertEquals(manifest.types, { "Using Callback": { type: "boolean" } });
 });
 
+Deno.test("Manifest() always sets token_management_enabled to false for runOnSlack: true apps", () => {
+  // When runOnSlack is explicitly specified as true, token_management_enabled must be set to false
+  const definition: SlackManifestType = {
+    runOnSlack: true,
+    name: "",
+    description: "",
+    backgroundColor: "#FFF",
+    longDescription: "",
+    displayName: "",
+    icon: "",
+    botScopes: [],
+  };
+  const manifest = Manifest(definition);
+  assertEquals(manifest.oauth_config.token_management_enabled, false);
+});
+
+Deno.test("Manifest() always sets token_management_enabled to false for function_runtime: slack apps", () => {
+  // SlackManifestType will default to function_runtime == slack when runOnSlack property omitted
+  // AND when no remote-only features are specified
+  const definition: SlackManifestType = {
+    name: "",
+    description: "",
+    backgroundColor: "#FFF",
+    longDescription: "",
+    displayName: "",
+    icon: "",
+    botScopes: [],
+  };
+  const manifest = Manifest(definition);
+  assertEquals(manifest.oauth_config.token_management_enabled, false);
+});
+
 Deno.test("Manifest() automatically registers types referenced by datastores", () => {
   const stringTypeId = "test_string_type";
   const objectTypeId = "test_object_type";

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -231,6 +231,10 @@ export class SlackManifest {
   private assignRunOnSlackManifestProperties(manifest: ManifestSchema) {
     const def = this.definition as ISlackManifestRunOnSlack;
 
+    // Run on Slack Apps do not manage access tokens
+    // This is set by default as false
+    manifest.oauth_config.token_management_enabled = false;
+
     // External Auth providers
     if (def.externalAuthProviders) {
       manifest.external_auth_providers = def.externalAuthProviders?.reduce(


### PR DESCRIPTION
###  Summary

`Manifest` now outputs `token_management_enabled: false` by default for all run on slack apps (aka where function_runtime is set as `slack`.

#### Developer Experience
* `tokenManagementEnabled` property does not appear in typeahead. In future, all run on slacks apps created should default to false in the backend so I figured it'd be better to keep this property out of sight. 

https://user-images.githubusercontent.com/55667998/181822386-6986a48f-37a7-4584-ab59-c5ac1ab487df.mov



* Manifest outputs the proper property

https://user-images.githubusercontent.com/55667998/181822461-28baa01e-2292-4441-8157-ea2991b92444.mov


* This does not impact remote / Bolt apps. tokenManagementFalse remains an [optional property f](https://github.com/slackapi/deno-slack-sdk/blob/5c61e062a0da51a30ab6ba0ce0378a31f93a8b0d/src/manifest/types.ts#L63)or these apps. 

### Requirements (place an `x` in each `[ ]`)



* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
