### PR TITLE
Adds RoS App Settings defaults: org_deploy_enabled

### DIFF
--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -371,7 +371,7 @@ Deno.test("Manifest() correctly assigns app_directory properties", () => {
   );
 });
 
-Deno.test("Manifest() correctly assigns settings properties", () => {
+Deno.test("Manifest() correctly assigns remote app settings properties", () => {
   const definition: SlackManifestType = {
     runOnSlack: false,
     name: "fear and loathing in las vegas",
@@ -438,6 +438,35 @@ Deno.test("Manifest() correctly assigns settings properties", () => {
     definition.settings?.siws_links,
   );
   assertStrictEquals(manifest.settings.function_runtime, "remote");
+
+  // When org_deploy_enabled not supplied, remote app settings default org deploy to true
+  const definition2: SlackManifestType = {
+    runOnSlack: false,
+    name: "",
+    description: "",
+    backgroundColor: "",
+    longDescription: "",
+    displayName: "",
+    icon: "",
+    botScopes: [],
+    settings: {},
+  };
+  const manifest2 = Manifest(definition2);
+  assertEquals(manifest2.settings.org_deploy_enabled, true);
+});
+
+Deno.test("Manifest() correctly assigns run on slack app settings properties", () => {
+  const definition: SlackManifestType = {
+    name: "",
+    description: "",
+    backgroundColor: "",
+    longDescription: "",
+    displayName: "",
+    icon: "",
+    botScopes: [],
+  };
+  const manifest = Manifest(definition);
+  assertEquals(manifest.settings.org_deploy_enabled, true);
 });
 
 Deno.test("Manifest() correctly assigns oauth properties", () => {

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -211,6 +211,13 @@ export class SlackManifest {
     manifest.settings.socket_mode_enabled = def.socketModeEnabled;
     manifest.settings.token_rotation_enabled = def.tokenRotationEnabled;
 
+    // Set org deploy enabled to true unless specified by dev
+    // Org deploy enabled is required to use remote functions
+    manifest.settings.org_deploy_enabled =
+      (def.settings?.org_deploy_enabled !== undefined)
+        ? def.settings?.org_deploy_enabled
+        : true;
+
     //AppDirectory
     manifest.app_directory = def.appDirectory;
 
@@ -244,5 +251,8 @@ export class SlackManifest {
         {} as NonNullable<ManifestSchema["external_auth_providers"]>,
       );
     }
+
+    // Required App Settings for run on slack apps
+    manifest.settings.org_deploy_enabled = true;
   }
 }

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -49,10 +49,10 @@ export interface ISlackManifestRemote extends ISlackManifestShared {
 
   settings?: Omit<
     ManifestSettingsSchema,
-    | "function_runtime"
     | "event_subscriptions"
     | "socket_mode_enabled"
     | "token_rotation_enabled"
+    | "function_runtime"
   >; // lifting omitted properties to top level
   eventSubscriptions?: ManifestEventSubscriptionsSchema;
   socketModeEnabled?: boolean;


### PR DESCRIPTION
###  Summary

Adds org_deploy_enabled: true for run on slack apps.

#### Developer Experience
* RoS App devs do not need to set this value, at the moment they also should not be able to set this value either, since there's no option but `true`.
* Remote App devs retain the ability to set this value via manifest.settings.org_deploy_enabled

https://user-images.githubusercontent.com/55667998/181834459-66048168-b96f-468d-a253-2c45f40d2bea.mov




### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
