### PR TITLE
changed Workflow definition to public

### DIFF
--- a/src/workflows/mod.ts
+++ b/src/workflows/mod.ts
@@ -43,7 +43,7 @@ export class WorkflowDefinition<
   RequiredOutputs extends PossibleParameterKeys<Outputs>,
 > implements ISlackWorkflow {
   public id: string;
-  private definition: SlackWorkflowDefinitionArgs<
+  public definition: SlackWorkflowDefinitionArgs<
     Inputs,
     Outputs,
     RequiredInputs,


### PR DESCRIPTION
###  Summary

Changed the definition field in WorkflowDefinition to a public variable.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
