### PR TITLE
adding slack#/types/date

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -81,7 +81,8 @@ type FunctionInputRuntimeType<
     : Param["type"] extends
       | typeof SlackSchemaTypes.user_id
       | typeof SlackSchemaTypes.usergroup_id
-      | typeof SlackSchemaTypes.channel_id ? string
+      | typeof SlackSchemaTypes.channel_id
+      | typeof SlackSchemaTypes.date ? string
     : Param["type"] extends typeof SlackSchemaTypes.timestamp ? number
     : UnknownRuntimeType;
 

--- a/src/schema/slack/types/mod.ts
+++ b/src/schema/slack/types/mod.ts
@@ -2,6 +2,7 @@ const SlackPrimitiveTypes = {
   user_id: "slack#/types/user_id",
   channel_id: "slack#/types/channel_id",
   usergroup_id: "slack#/types/usergroup_id",
+  date: "slack#/types/date",
   timestamp: "slack#/types/timestamp",
   blocks: "slack#/types/blocks",
   oauth2: "slack#/types/credential/oauth2",


### PR DESCRIPTION
###  Summary

Adds `slack#/types/date` to the `Schema`. At runtime it's a string (it's format is `YYYY-MM-DD`).

### Testing
To test this you can use an Open Form step and add a field of `Schema.slack.types.date` - it should render a date-picker like in the screenshot.

<img width="508" alt="image" src="https://user-images.githubusercontent.com/367275/184223794-055d530d-acb8-44b4-b914-a785a54c55fc.png">

You can embed that output into a Send a message step's `message` input and you should see the date string you selected, like so:

<img width="417" alt="image" src="https://user-images.githubusercontent.com/367275/184224022-9a5cc7b2-937d-46ed-99ff-55afca7f34e9.png">

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
