### PR TITLE
Exposing team_id to FunctionContext

### DIFF
--- a/src/functions/interactivity/action_router_test.ts
+++ b/src/functions/interactivity/action_router_test.ts
@@ -128,6 +128,7 @@ const SlackActionHandlerTester: SlackActionHandlerTesterFn = <
       inputs,
       env: args.env || {},
       token: args.token || "slack-function-test-token",
+      team_id: args.team_id || "test-team-id",
       action: args.action || DEFAULT_ACTION,
       body: args.body || DEFAULT_BODY,
     };

--- a/src/functions/interactivity/view_router_test.ts
+++ b/src/functions/interactivity/view_router_test.ts
@@ -198,6 +198,7 @@ const SlackViewSubmissionHandlerTester: SlackViewSubmissionHandlerTesterFn = <
       token: args.token || "slack-function-test-token",
       view: args.view || DEFAULT_VIEW,
       body: args.body || DEFAULT_BODY,
+      team_id: DEFAULT_VIEW.team_id,
     };
   };
 
@@ -265,6 +266,7 @@ const SlackViewClosedHandlerTester: SlackViewClosedHandlerTesterFn = <
       token: args.token || "slack-function-test-token",
       view: args.view || DEFAULT_VIEW,
       body: args.body || DEFAULT_BODY,
+      team_id: DEFAULT_VIEW.team_id,
     };
   };
 

--- a/src/functions/tester/mod.ts
+++ b/src/functions/tester/mod.ts
@@ -47,6 +47,7 @@ export const SlackFunctionTester: SlackFunctionTesterFn = <
       >,
       env: args.env || {},
       token: args.token || "slack-function-test-token",
+      team_id: args.team_id || "test-team-id",
       event: args.event || {
         type: "function_executed",
         event_ts: `${ts.getTime()}`,

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -202,7 +202,14 @@ export type FunctionContext<
    * @description The inputs to the function as defined by your function definition. If no inputs are specified, an empty object is provided at runtime.
    */
   inputs: InputParameters;
+  /**
+   * @description API token that can be used with the deno-slack-api API client.
+   */
   token: string;
+  /**
+   * @description A unique encoded ID representing the Slack team associated with the workspace where the function execution takes place.
+   */
+  team_id: string;
   event: FunctionInvocationBody["event"];
 };
 


### PR DESCRIPTION
`team_id` should now be available on all dispatched events to userland functions via runtime.