### PR TITLE
[PAX-11407] [merge after 8/25] removing client_secret_env_key from manifest

### DIFF
--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -804,7 +804,6 @@ Deno.test("SlackManifest() oauth2 providers get set properly", () => {
     provider_type: Schema.providers.oauth2.CUSTOM,
     options: {
       "client_id": "123.456",
-      "client_secret_env_key": "secret_key",
       "scope": ["scope_a", "scope_b"],
     },
   });

--- a/src/providers/oauth2/types.ts
+++ b/src/providers/oauth2/types.ts
@@ -11,8 +11,6 @@ export type OAuth2ProviderIdentitySchema = {
 export type OAuth2ProviderOptions = {
   /** Client id for your provider */
   "client_id": string;
-  /** Client secret for your provider */
-  "client_secret_env_key": string;
   /** Scopes for your provider */
   "scope": string[];
   /** Display name for your provider. Required for CUSTOM provider types. */


### PR DESCRIPTION
###  Summary
Jira ticket: https://jira.tinyspeck.com/browse/PAX-11407
- The environment variable name `client_secret_env_key` became redundant and the internal 3p auth users are supposed to be using a new subcommand  `add-secret` instead of the .env variable
- Therefore we are removing the field `client_secret_env_key` from the SDK object
- The webapp should be okay to accept the oauth2 object now if this field is optional there (TODO check)
- There will be a CLI change as well to get rid of this field completely. [PR](https://github.com/slackapi/slack-cli/pull/682)
- This PR can be merged after the new `add-secret` subcommand is available to the end user.

How to test:
- This needs to be tested after the `client_secret_env_key` field becomes optional in the [PR](https://slack-github.com/slack/webapp/pull/151759) 
- We need to update the SDK to point to this version by creating an app and updating the `import_map.json` file
- Try updating the manifest with a provider object that doesnt have the `client_secret_env_key` field
- There should be no error when the app is deployed 
- Both `client_secret` and `client_secret_env_key` field should be empty in the `providers` table in db
import.map file example: 
```
{
  "imports": {
    "deno-slack-sdk/": "https://raw.githubusercontent.com/slackapi/deno-slack-sdk/6527d84/src/",
    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.3/"
  }
}
 ```
Manifest.ts file in app file example:
```

const GoogleProvider = DefineOAuth2Provider({
  provider_key: "google",
  provider_type: Schema.providers.oauth2.CUSTOM,
  options: {
    "provider_name": "Google",
    "authorization_url": "https://accounts.google.com/o/oauth2/auth",
    "token_url": "https://oauth2.googleapis.com/token",
    "client_id":
      "1086877417652-b1o23iogo2dqithh2rrspt967i70kig6.apps.googleusercontent.com",
     //  "client_secret_env_key": "google_client_secret", --> this is deleted
    "scope": [
      "https://www.googleapis.com/auth/spreadsheets",
      "https://www.googleapis.com/auth/userinfo.email",
      "https://www.googleapis.com/auth/userinfo.profile",
    ],
    "authorization_url_extras": {
      "prompt": "consent",
      "access_type": "offline",
    },
    "identity_config": {
      "url": "https://www.googleapis.com/oauth2/v1/userinfo",
      "account_identifier": "$.email",
    },
  },
});

```



### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
