### PR TITLE
[PAX-10934] Add credential source (merge after 8/25)

### DIFF
--- a/src/schema/credentials/mod.ts
+++ b/src/schema/credentials/mod.ts
@@ -1,0 +1,7 @@
+import CredentialSources from "./source/mod.ts";
+
+const Schema = {
+  source: CredentialSources,
+} as const;
+
+export default Schema;

--- a/src/schema/credentials/source/mod.ts
+++ b/src/schema/credentials/source/mod.ts
@@ -1,5 +1,5 @@
 const CredentialSource = {
-  BUILDER: "BUILDER",
+  DEVELOPER: "DEVELOPER",
 } as const;
 
 export default CredentialSource;

--- a/src/schema/credentials/source/mod.ts
+++ b/src/schema/credentials/source/mod.ts
@@ -1,0 +1,5 @@
+const CredentialSource = {
+  BUILDER: "BUILDER",
+} as const;
+
+export default CredentialSource;

--- a/src/schema/credentials/source/types.ts
+++ b/src/schema/credentials/source/types.ts
@@ -1,0 +1,4 @@
+import CredentialSource from "./mod.ts";
+
+export type CredentialSourceValues =
+  typeof CredentialSource[keyof typeof CredentialSource];

--- a/src/schema/mod.ts
+++ b/src/schema/mod.ts
@@ -1,6 +1,7 @@
 import SchemaTypes from "./schema_types.ts";
 import SlackSchema from "./slack/mod.ts";
 import Providers from "./providers/mod.ts";
+import Credentials from "./credentials/mod.ts";
 
 const Schema = {
   // Contains primitive types
@@ -8,6 +9,7 @@ const Schema = {
   // Contains slack-specific schema types
   slack: SlackSchema,
   providers: Providers,
+  credentials: Credentials,
 } as const;
 
 export default Schema;


### PR DESCRIPTION
###  Summary

In this PR, I'm introducing a way for developers to configure the credential source they want to use for 3P Auth steps. In [this thread](https://slack-pde.slack.com/archives/C02HWTPG26T/p1660871717220039), we discussed allowing developers to specify an empty object in the `addStep` configuration for Open Beta. This was primarily because we weren't sure if we would have bandwidth to make the SDK changes before Open Beta.

With this PR, instead of an empty object, developers will add 👇 
```
const step1 = workflow.addStep(ReverseFunction, {
  stringToReverse: workflow.inputs.stringToReverse,
  googleAccessToken: {
    "credentialSource": Schema.credentials.source.BUILDER,
  },
});
``` 
In the future, we will add more sources like `USER`. 

In the future, we would also like to do type checking on the `addStep` configuration so that the SDK can enforce this schema. Today, validation will only happen on the server side in webapp.

This will be merged before the 9/1 cutoff for the 9/8 release. 

### Requirements (place an `x` in each `[ ]`)
* [X] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
