### PR TITLE
Add support for custom metadata events

### DIFF
--- a/src/events/mod.ts
+++ b/src/events/mod.ts
@@ -1,0 +1,62 @@
+import { SlackManifest } from "../manifest/mod.ts";
+import { ManifestCustomEventSchema } from "../manifest/manifest_schema.ts";
+import {
+  CustomEventDefinition,
+  DefineEventSignature,
+  ICustomEvent,
+} from "./types.ts";
+
+export const DefineEvent: DefineEventSignature = <
+  Def extends CustomEventDefinition,
+>(
+  definition: Def,
+) => {
+  return new CustomEvent(definition);
+};
+
+export class CustomEvent<Def extends CustomEventDefinition>
+  implements ICustomEvent {
+  public id: string;
+  public title: string | undefined;
+  public description: string | undefined;
+
+  constructor(
+    public definition: Def,
+  ) {
+    this.id = definition.name;
+    this.definition = definition;
+    this.description = definition.description;
+    this.title = definition.title;
+  }
+
+  private generateReferenceString() {
+    return this.id;
+  }
+
+  toString() {
+    return this.generateReferenceString();
+  }
+
+  toJSON() {
+    return this.generateReferenceString();
+  }
+
+  registerParameterTypes(manifest: SlackManifest) {
+    if ("properties" in this.definition) {
+      // Loop through the properties and register any types
+      Object.values(this.definition.properties)?.forEach((property) => {
+        if ("type" in property && property.type instanceof Object) {
+          manifest.registerType(property.type);
+        }
+      });
+    } else if (this.definition.type instanceof Object) {
+      // The referenced type is a Custom Type
+      manifest.registerType(this.definition.type);
+    }
+  }
+  export(): ManifestCustomEventSchema {
+    // remove name from the definition we pass to the manifest
+    const { name: _n, ...definition } = this.definition;
+    return definition;
+  }
+}

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,0 +1,33 @@
+import {
+  CustomTypeParameterDefinition,
+  TypedObjectParameterDefinition,
+} from "../parameters/types.ts";
+import { ManifestCustomEventSchema } from "../manifest/manifest_schema.ts";
+import { CustomEvent } from "./mod.ts";
+import { SlackManifest } from "../manifest/mod.ts";
+
+type AcceptedEventTypes =
+  | TypedObjectParameterDefinition
+  | CustomTypeParameterDefinition;
+
+export type CustomEventDefinition =
+  & {
+    /**
+     * The name of your event
+     * @example my_custom_event
+     */
+    name: string;
+  }
+  & AcceptedEventTypes;
+
+export type DefineEventSignature = {
+  <Def extends CustomEventDefinition>(definition: Def): CustomEvent<Def>;
+};
+
+export interface ICustomEvent {
+  id: string;
+  definition: CustomEventDefinition;
+  description?: string;
+  registerParameterTypes: (manifest: SlackManifest) => void;
+  export(): ManifestCustomEventSchema;
+}

--- a/src/events/types_test.ts
+++ b/src/events/types_test.ts
@@ -1,0 +1,43 @@
+import { DefineEvent } from "./mod.ts";
+import { assertEquals } from "../dev_deps.ts";
+import { DefineType, Schema } from "../mod.ts";
+import { CustomType } from "../types/mod.ts";
+
+Deno.test("DefineEvent accepts object types", () => {
+  const TestEvent = DefineEvent({
+    name: "test",
+    type: Schema.types.object,
+    properties: {},
+  });
+
+  assertEquals(typeof TestEvent.definition.type, "string");
+});
+
+Deno.test("DefineEvent accepts custom types", () => {
+  const TestType = DefineType({
+    name: "test",
+    type: Schema.types.object,
+    properties: {},
+  });
+
+  const TestEvent = DefineEvent({
+    title: "Title",
+    description: "Description",
+    name: "test",
+    type: TestType,
+  });
+
+  assertEquals(TestEvent.definition.type instanceof CustomType, true);
+});
+
+Deno.test("DefineEvent is properly stringified", () => {
+  const TestEvent = DefineEvent({
+    name: "test",
+    type: Schema.types.object,
+    properties: {},
+  });
+
+  assertEquals(`${TestEvent}`, TestEvent.id);
+  assertEquals(TestEvent.toJSON(), TestEvent.id);
+  assertEquals(TestEvent.toString(), TestEvent.id);
+});

--- a/src/manifest/manifest_schema.ts
+++ b/src/manifest/manifest_schema.ts
@@ -25,6 +25,7 @@ export type ManifestSchema = {
   outgoing_domains?: string[];
   types?: ManifestCustomTypesSchema;
   datastores?: ManifestDataStoresSchema;
+  events?: ManifestCustomEventsSchema;
   external_auth_providers?: ManifestExternalAuthProviders;
 };
 
@@ -246,6 +247,15 @@ export type ManifestWorkflowStepSchema = {
   };
 };
 
+// ---------------------------------------------------------------------------
+// Manifest: Custom Events
+// ---------------------------------------------------------------------------
+
+export type ManifestCustomEventSchema = ParameterDefinition;
+
+export type ManifestCustomEventsSchema = {
+  [key: string]: ManifestCustomEventSchema;
+};
 // ---------------------------------------------------------------------------
 // Manifest: Custom Types
 // ---------------------------------------------------------------------------

--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -6,6 +6,7 @@ import {
 import { Manifest, SlackManifest } from "./mod.ts";
 import {
   DefineDatastore,
+  DefineEvent,
   DefineFunction,
   DefineOAuth2Provider,
   DefineType,
@@ -283,6 +284,63 @@ Deno.test("Manifest() automatically registers types referenced by datastores", (
   assertEquals(manifest.types, {
     [stringTypeId]: StringType.export(),
     [objectTypeId]: ObjectType.export(),
+  });
+});
+
+Deno.test("Manifest() automatically registers types referenced by events", () => {
+  const objectTypeId = "test_object_type";
+  const stringTypeId = "test_string_type";
+  const booleanTypeId = "test_boolean_type";
+  const arrayTypeId = "test_array_type";
+
+  const BooleanType = DefineType({
+    name: booleanTypeId,
+    type: Schema.types.boolean,
+  });
+
+  const StringType = DefineType({
+    name: stringTypeId,
+    type: Schema.types.string,
+  });
+
+  const ArrayType = DefineType({
+    name: arrayTypeId,
+    type: Schema.types.array,
+    items: {
+      type: StringType,
+    },
+  });
+
+  const ObjectType = DefineEvent({
+    name: objectTypeId,
+    type: Schema.types.object,
+    properties: {
+      aBoolean: { type: BooleanType },
+      anArray: { type: ArrayType },
+    },
+  });
+
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    longDescription: "LongDescription",
+    botScopes: [],
+    types: [ObjectType],
+  };
+  const manifest = Manifest(definition);
+
+  assertEquals(definition.types, [
+    ObjectType,
+    BooleanType,
+    ArrayType,
+    StringType,
+  ]);
+  assertEquals(manifest.types, {
+    [objectTypeId]: ObjectType.export(),
+    [booleanTypeId]: BooleanType.export(),
+    [arrayTypeId]: ArrayType.export(),
+    [stringTypeId]: StringType.export(),
   });
 });
 

--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -288,7 +288,7 @@ Deno.test("Manifest() automatically registers types referenced by datastores", (
 });
 
 Deno.test("Manifest() automatically registers types referenced by events", () => {
-  const objectTypeId = "test_object_type";
+  const objectEventId = "test_object_type";
   const stringTypeId = "test_string_type";
   const booleanTypeId = "test_boolean_type";
   const arrayTypeId = "test_array_type";
@@ -311,8 +311,8 @@ Deno.test("Manifest() automatically registers types referenced by events", () =>
     },
   });
 
-  const ObjectType = DefineEvent({
-    name: objectTypeId,
+  const ObjectEvent = DefineEvent({
+    name: objectEventId,
     type: Schema.types.object,
     properties: {
       aBoolean: { type: BooleanType },
@@ -326,18 +326,18 @@ Deno.test("Manifest() automatically registers types referenced by events", () =>
     icon: "icon.png",
     longDescription: "LongDescription",
     botScopes: [],
-    types: [ObjectType],
+    events: [ObjectEvent],
   };
   const manifest = Manifest(definition);
 
+  assertEquals(definition.events, [ObjectEvent]);
+  assertEquals(manifest.events, { [objectEventId]: ObjectEvent.export() });
   assertEquals(definition.types, [
-    ObjectType,
     BooleanType,
     ArrayType,
     StringType,
   ]);
   assertEquals(manifest.types, {
-    [objectTypeId]: ObjectType.export(),
     [booleanTypeId]: BooleanType.export(),
     [arrayTypeId]: ArrayType.export(),
     [stringTypeId]: StringType.export(),

--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -288,7 +288,9 @@ Deno.test("Manifest() automatically registers types referenced by datastores", (
 });
 
 Deno.test("Manifest() automatically registers types referenced by events", () => {
-  const objectEventId = "test_object_type";
+  const objectEventTypeId = "test_object_event_type";
+  const objectTypeId = "test_object_type";
+  const objectEventId = "test_object_event";
   const stringTypeId = "test_string_type";
   const booleanTypeId = "test_boolean_type";
   const arrayTypeId = "test_array_type";
@@ -311,6 +313,14 @@ Deno.test("Manifest() automatically registers types referenced by events", () =>
     },
   });
 
+  const ObjectType = DefineType({
+    name: objectTypeId,
+    type: Schema.types.object,
+    properties: {
+      aBoolean: { type: BooleanType },
+    },
+  });
+
   const ObjectEvent = DefineEvent({
     name: objectEventId,
     type: Schema.types.object,
@@ -320,24 +330,34 @@ Deno.test("Manifest() automatically registers types referenced by events", () =>
     },
   });
 
+  const ObjectTypeEvent = DefineEvent({
+    name: objectEventTypeId,
+    type: ObjectType,
+  });
+
   const definition: SlackManifestType = {
     name: "Name",
     description: "Description",
     icon: "icon.png",
     longDescription: "LongDescription",
     botScopes: [],
-    events: [ObjectEvent],
+    events: [ObjectTypeEvent, ObjectEvent],
   };
   const manifest = Manifest(definition);
 
-  assertEquals(definition.events, [ObjectEvent]);
-  assertEquals(manifest.events, { [objectEventId]: ObjectEvent.export() });
+  assertEquals(definition.events, [ObjectTypeEvent, ObjectEvent]);
+  assertEquals(manifest.events, {
+    [objectEventTypeId]: ObjectTypeEvent.export(),
+    [objectEventId]: ObjectEvent.export(),
+  });
   assertEquals(definition.types, [
+    ObjectType,
     BooleanType,
     ArrayType,
     StringType,
   ]);
   assertEquals(manifest.types, {
+    [objectTypeId]: ObjectType.export(),
     [booleanTypeId]: BooleanType.export(),
     [arrayTypeId]: ArrayType.export(),
     [stringTypeId]: StringType.export(),

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -7,6 +7,7 @@ import { ICustomType } from "../types/types.ts";
 import { OAuth2Provider } from "../providers/oauth2/mod.ts";
 import { ParameterSetDefinition } from "../parameters/mod.ts";
 import {
+  ManifestCustomEventsSchema,
   ManifestCustomTypesSchema,
   ManifestDataStoresSchema,
   ManifestFunction,
@@ -100,6 +101,16 @@ export class SlackManifest {
       );
     }
 
+    if (def.events) {
+      manifest.events = def.events?.reduce<ManifestCustomEventsSchema>(
+        (acc = {}, event) => {
+          acc[event.id] = event.export();
+          return acc;
+        },
+        {},
+      );
+    }
+
     if (def.features?.appHome) {
       const {
         homeTabEnabled,
@@ -140,6 +151,11 @@ export class SlackManifest {
     // Loop through datastores to automatically register any referenced types
     this.definition.datastores?.forEach((datastore) => {
       datastore.registerAttributeTypes(this);
+    });
+
+    // Loop through events to automatically register any referenced types
+    this.definition.events?.forEach((event) => {
+      event.registerParameterTypes(this);
     });
 
     // Loop through types to automatically register any referenced sub-types

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -15,6 +15,7 @@ import {
 import { OAuth2Provider } from "../providers/oauth2/mod.ts";
 import { ICustomType } from "../types/types.ts";
 import { CamelCasedPropertiesDeep } from "./types_util.ts";
+import { ICustomEvent } from "../events/types.ts";
 
 /** Manifest definition.
  *
@@ -76,6 +77,7 @@ interface ISlackManifestShared {
   functions?: ManifestFunction[];
   workflows?: ManifestWorkflow[];
   outgoingDomains?: Array<string>;
+  events?: ICustomEvent[];
   types?: ICustomType[];
   datastores?: ManifestDatastore[];
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,6 +12,7 @@ export {
 } from "./functions/interactivity/mod.ts";
 export type { ViewEvents } from "./functions/interactivity/view_types.ts";
 export { DefineWorkflow } from "./workflows/mod.ts";
+export { DefineEvent } from "./events/mod.ts";
 export { DefineType } from "./types/mod.ts";
 export { DefineOAuth2Provider } from "./providers/oauth2/mod.ts";
 export { default as Schema } from "./schema/mod.ts";


### PR DESCRIPTION
###  Summary

This PR adds support for defining events on the App Manifest.

#### Feature Details
When an app uses `chat.postMessage` from inside a function, they can optionally pass a `metadata` object. That `metadata` object will have an `event_type` and an `event_payload`. If the `event_type` matches one of the keys from the app manifest's `events` object, the `event_payload` needs to match the metadata schema.
* If there are required properties that are missing, the message will still successfully post but the metadata will be dropped and the response will include a `warning` and a `response_metadata` object.
  * There are plans to eventually support a "strict mode" that will fail the `postMessage` call entirely, but that's not currently supported.
* If there are additional properties that are not defined in the manifest, the message will be successfully posted with metadata. If validation should catch the extra properties, the Event must set `additionalProperties: false`

#### SDK Usage

```ts
// manifest.ts
export const MyEvent = DefineEvent({
  name: "my_event",
  type: Schema.types.object,
  properties: {
    id: { type: Schema.types.string },
    summary: { type: Schema.types.string },
  },
  required: ["id", "summary"],
});

export default Manifest({
  ...,
  events: [MyEvent], 
});

// function.ts
import { MyEvent } from "../manifest.ts";

...
const post = await client.chat.postMessage({
    channel: inputs.channel,
    text: "Hello this has metadata",
    metadata: {
      event_type: MyEvent, // this turns into the "my_event" string
      event_payload: {
        id: "my_id",
        summary: "This is a summary of the event",
      },
    },
  });
```

### Testing
1. Create an Event on your manifest of object type and verify manifest validation works
2. Turn that object into a custom type and verify manifest validation works
3. Use that event in a `chat.postMessage` call where your structure matches the expectation
4. Change the `chat.postMessage` call where the structure no longer matches
5. BONUS: Set up an event trigger to fire based on the message metadata being posted


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
