### PR TITLE
Check for additionalProperties to be set to false

### DIFF
--- a/src/functions/interactivity/block_actions_types.ts
+++ b/src/functions/interactivity/block_actions_types.ts
@@ -76,6 +76,7 @@ export type BlockActionsBody = {
     id: string;
     /**
      * @description User's handle as seen in the Slack client when e.g. at-notifying the user.
+     */
     name: string;
     /**
      * @description The encoded team ID for the workspace, or team, where the Block Kit action originated from.

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -93,15 +93,20 @@ type UnknownRuntimeType = any;
 
 type TypedObjectFunctionInputRuntimeType<
   Param extends TypedObjectParameterDefinition,
-> =
-  & {
+> = Param["additionalProperties"] extends false ? {
     [k in keyof Param["properties"]]: FunctionInputRuntimeType<
       Param["properties"][k]
     >;
   }
-  & {
-    [key: string]: UnknownRuntimeType;
-  };
+  : 
+    & {
+      [k in keyof Param["properties"]]: FunctionInputRuntimeType<
+        Param["properties"][k]
+      >;
+    }
+    & {
+      [key: string]: UnknownRuntimeType;
+    };
 
 type TypedArrayFunctionInputRuntimeType<
   Param extends TypedArrayParameterDefinition,

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -53,13 +53,13 @@ type ObjectParameterPropertyTypes<Def extends TypedObjectParameterDefinition> =
 // If additionalProperties is set to true, allow access to any key.
 // Otherwise, only allow keys provided through use of properties
 type ObjectParameterVariableType<Def extends TypedObjectParameterDefinition> =
-  Def["additionalProperties"] extends true ? 
+  Def["additionalProperties"] extends false ? ObjectParameterPropertyTypes<Def>
+    : 
       & ObjectParameterPropertyTypes<Def>
       & {
         // deno-lint-ignore no-explicit-any
         [key: string]: any;
-      }
-    : ObjectParameterPropertyTypes<Def>;
+      };
 
 export const ParameterVariable = <P extends ParameterDefinition>(
   namespace: string,

--- a/src/parameters/parameter-variable_test.ts
+++ b/src/parameters/parameter-variable_test.ts
@@ -29,6 +29,24 @@ Deno.test("ParameterVariable typed object", () => {
   assertStrictEquals(`${param.name}`, "{{incident.name}}");
 });
 
+Deno.test("ParameterVariable typed object allows access to additional properties", () => {
+  const param = ParameterVariable("", "incident", {
+    type: SchemaTypes.object,
+    properties: {
+      id: {
+        type: SchemaTypes.integer,
+      },
+      name: {
+        type: SchemaTypes.string,
+      },
+    },
+  });
+
+  assertStrictEquals(`${param}`, "{{incident}}");
+  assertStrictEquals(`${param.id}`, "{{incident.id}}");
+  assertStrictEquals(`${param.name}`, "{{incident.name}}");
+  assertStrictEquals(`${param.foo.bar}`, "{{incident.foo.bar}}");
+});
 Deno.test("ParameterVariable typed object with additional properties", () => {
   const param = ParameterVariable("", "incident", {
     type: SchemaTypes.object,
@@ -46,6 +64,28 @@ Deno.test("ParameterVariable typed object with additional properties", () => {
   assertStrictEquals(`${param}`, "{{incident}}");
   assertStrictEquals(`${param.id}`, "{{incident.id}}");
   assertStrictEquals(`${param.name}`, "{{incident.name}}");
+  assertStrictEquals(`${param.foo.bar}`, "{{incident.foo.bar}}");
+});
+
+Deno.test("ParameterVariable typed object with no additional properties", () => {
+  const param = ParameterVariable("", "incident", {
+    type: SchemaTypes.object,
+    properties: {
+      id: {
+        type: SchemaTypes.integer,
+      },
+      name: {
+        type: SchemaTypes.string,
+      },
+    },
+    additionalProperties: false,
+  });
+
+  assertStrictEquals(`${param}`, "{{incident}}");
+  assertStrictEquals(`${param.id}`, "{{incident.id}}");
+  assertStrictEquals(`${param.name}`, "{{incident.name}}");
+
+  //@ts-expect-error foo doesn't exist
   assertStrictEquals(`${param.foo.bar}`, "{{incident.foo.bar}}");
 });
 

--- a/src/parameters/parameter-variable_test.ts
+++ b/src/parameters/parameter-variable_test.ts
@@ -47,6 +47,7 @@ Deno.test("ParameterVariable typed object allows access to additional properties
   assertStrictEquals(`${param.name}`, "{{incident.name}}");
   assertStrictEquals(`${param.foo.bar}`, "{{incident.foo.bar}}");
 });
+
 Deno.test("ParameterVariable typed object with additional properties", () => {
   const param = ParameterVariable("", "incident", {
     type: SchemaTypes.object,

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -49,7 +49,10 @@ export type TypedObjectParameterDefinition =
   & {
     /** A list of required property names (must reference names defined on the `properties` property). Only for use with Object types. */
     required?: string[];
-    /** Whether the parameter can accept objects with additional keys beyond those defined via `properties` */
+    /**
+     * Whether the parameter can accept objects with additional keys beyond those defined via `properties`
+     * @default "true"
+     */
     additionalProperties?: boolean;
     /** Object defining what properties are allowed on the parameter. */
     properties: {


### PR DESCRIPTION
###  Summary

The backend defaults `additionalProperties` on parameters of the `object` type to true, so this PR inverts the check to see if they are explicitly setting `additionalProperties` to false.

### Testing
1. Create an `object` parameter as a function input or output
2. Verify that at both workflow authoring time and at runtime, you're able to access unexpected properties.
3. Change the object parameters you created to set `additionalProperties: false`
4. Notice that your access of unexpected properties now results in errors.

```ts
anObject: {
        type: Schema.types.object,
        properties: {
            test: { type: Schema.types.string },
        },
        additionalProperties: false,
      },
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
