### PR TITLE
Make the workflow callback_id generic

### DIFF
--- a/src/workflows/mod.ts
+++ b/src/workflows/mod.ts
@@ -25,12 +25,14 @@ export const DefineWorkflow = <
   Outputs extends ParameterSetDefinition,
   RequiredInputs extends PossibleParameterKeys<Inputs>,
   RequiredOutputs extends PossibleParameterKeys<Outputs>,
+  CallbackID extends string,
 >(
   definition: SlackWorkflowDefinitionArgs<
     Inputs,
     Outputs,
     RequiredInputs,
-    RequiredOutputs
+    RequiredOutputs,
+    CallbackID
   >,
 ) => {
   return new WorkflowDefinition(definition);
@@ -41,13 +43,15 @@ export class WorkflowDefinition<
   Outputs extends ParameterSetDefinition,
   RequiredInputs extends PossibleParameterKeys<Inputs>,
   RequiredOutputs extends PossibleParameterKeys<Outputs>,
+  CallbackID extends string,
 > implements ISlackWorkflow {
   public id: string;
   public definition: SlackWorkflowDefinitionArgs<
     Inputs,
     Outputs,
     RequiredInputs,
-    RequiredOutputs
+    RequiredOutputs,
+    CallbackID
   >;
 
   public inputs: WorkflowInputs<
@@ -67,7 +71,8 @@ export class WorkflowDefinition<
       Inputs,
       Outputs,
       RequiredInputs,
-      RequiredOutputs
+      RequiredOutputs,
+      CallbackID
     >,
   ) {
     this.id = definition.callback_id;

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -15,8 +15,8 @@ export interface ISlackWorkflow {
 }
 
 export type SlackWorkflowDefinition<Definition> = Definition extends
-  SlackWorkflowDefinitionArgs<infer I, infer O, infer RI, infer RO>
-  ? SlackWorkflowDefinitionArgs<I, O, RI, RO>
+  SlackWorkflowDefinitionArgs<infer I, infer O, infer RI, infer RO, infer CB>
+  ? SlackWorkflowDefinitionArgs<I, O, RI, RO, CB>
   : never;
 
 export type SlackWorkflowDefinitionArgs<
@@ -24,8 +24,9 @@ export type SlackWorkflowDefinitionArgs<
   OutputParameters extends ParameterSetDefinition,
   RequiredInputs extends PossibleParameterKeys<InputParameters>,
   RequiredOutputs extends PossibleParameterKeys<OutputParameters>,
+  CallbackID extends string,
 > = {
-  callback_id: string;
+  callback_id: CallbackID;
   title: string;
   description?: string;
   "input_parameters"?: ParameterPropertiesDefinition<


### PR DESCRIPTION
###  Summary

This makes it so that we respect the value passed into `callback_id`, rather than treating it as any old `string`. This is necessary for us to key off of `callback_id` to know what should be passed into a trigger's `workflow` parameter in the API.

#### Testing
There is no functional difference here, but you could test making and deploying workflows for a sanity check.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
