### PR TITLE
PSA-2507 : Add new attribute hint to Function parameters

### DIFF
--- a/src/functions/functions_test.ts
+++ b/src/functions/functions_test.ts
@@ -30,14 +30,17 @@ Deno.test("Function with required params", () => {
           type: Schema.types.string,
           title: "My string",
           description: "a really neat value",
+          hint: "Ex. my neat value",
         },
         myBoolean: {
           type: Schema.types.boolean,
           title: "My boolean",
+          hint: "Ex: true/false",
         },
         myInteger: {
           type: Schema.types.integer,
           description: "integer",
+          hint: "0-100",
         },
         myNumber: {
           type: Schema.types.number,
@@ -63,6 +66,14 @@ Deno.test("Function with required params", () => {
   assertEquals(AllTypesFunction.definition.output_parameters?.required, [
     "out",
   ]);
+  assertEquals(
+    AllTypesFunction.definition.input_parameters?.properties.myString.hint,
+    "Ex. my neat value",
+  );
+  assertEquals(
+    AllTypesFunction.definition.input_parameters?.properties.myBoolean.hint,
+    "Ex: true/false",
+  );
 });
 
 Deno.test("Function without input and output parameters", () => {

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -31,6 +31,8 @@ type BaseParameterDefinition<T> = {
   title?: string;
   /** An optional parameter description. */
   description?: string;
+  /** An optional parameter hint. */
+  hint?: string;
   /** An optional parameter default value. */
   default?: T;
   /** An option list of examples; intended for future use in a possible app type schemas page. */


### PR DESCRIPTION
###  Summary

[PSA-2507](https://jira.tinyspeck.com/browse/PSA-2507) - For function parameters, we are introducing a new attribute `hint` . This can be used to display warnings or any text that is in addition to title, description and it will be displayed under the input field.

Refer this  [Tech spec](https://corp.quip.com/yTZNAw5OUNKv/Tech-Spec-Add-a-new-optional-property-hint-to-function-parameters) for the details.

## Testing
1. Create a new Hermes app ( reverse string template ), Add `hint` attribute to `Reverse string` function param. 
```
export const ReverseFunction = DefineFunction({
  callback_id: "reverse_hint",
  title: "Reverse hint",
  description: "Takes a string and reverses it",
  source_file: "functions/reverse.ts",
  input_parameters: {
    properties: {
      stringToReverse: {
        type: Schema.types.string,
        description: "The string to reverse",
        hint: "Some random hint",
      },
    },
    required: ["stringToReverse"],
  },
  output_parameters: {
    properties: {
      reverseString: {
        type: Schema.types.string,
        description: "The string in reverse",
      },
    },
    required: ["reverseString"],
  },
});

```
3. `import_map.json` to point to local SDK
4. Deploy app to a dev workspace
5. Check output of  `functions.list` on the same workspace and see `hint` parameter appears in the `Reverse String` function. 

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
