### PR TITLE
Default token_management_enabled:true for runOnSlack:false apps

### DIFF
--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -246,6 +246,21 @@ Deno.test("Manifest() always sets token_management_enabled to false for function
   assertEquals(manifest.oauth_config.token_management_enabled, false);
 });
 
+Deno.test("Manifest() sets token_management_enabled to true by default for runOnSlack: false apps", () => {
+  const definition: SlackManifestType = {
+    runOnSlack: false,
+    name: "",
+    description: "",
+    backgroundColor: "",
+    longDescription: "",
+    displayName: "",
+    icon: "",
+    botScopes: [],
+  };
+  const manifest = Manifest(definition);
+  assertEquals(manifest.oauth_config.token_management_enabled, true);
+});
+
 Deno.test("Manifest() automatically registers types referenced by datastores", () => {
   const stringTypeId = "test_string_type";
   const objectTypeId = "test_object_type";
@@ -515,7 +530,6 @@ Deno.test("Manifest() correctly assigns oauth properties", () => {
     botScopes: ["channels:history", "chat:write", "commands"],
     userScopes: ["admin", "calls:read"],
     redirectUrls: ["https://api.slack.com/", "https://app.slack.com/"],
-    tokenManagementEnabled: false,
   };
   const manifest = Manifest(definition);
   //oauth
@@ -529,7 +543,7 @@ Deno.test("Manifest() correctly assigns oauth properties", () => {
   );
   assertStrictEquals(
     manifest.oauth_config.token_management_enabled,
-    definition.tokenManagementEnabled,
+    true,
   );
 });
 

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -228,7 +228,9 @@ export class SlackManifest {
     //OauthConfig
     manifest.oauth_config.scopes.user = def.userScopes;
     manifest.oauth_config.redirect_urls = def.redirectUrls;
-    manifest.oauth_config.token_management_enabled = def.tokenManagementEnabled;
+
+    // Remote-hosted Slack apps manage their own tokens
+    manifest.oauth_config.token_management_enabled = true;
 
     // Remote Features
     manifest.features.bot_user!.always_online = def.features?.botUser

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -60,7 +60,6 @@ export interface ISlackManifestRemote extends ISlackManifestShared {
   appDirectory?: ManifestAppDirectorySchema;
   userScopes?: Array<string>;
   redirectUrls?: Array<string>;
-  tokenManagementEnabled?: boolean;
   features?: ISlackManifestRemoteFeaturesSchema;
 }
 


### PR DESCRIPTION
###  Summary

Removes `tokenManagementEnabled` top level property from the Manifest definition, and sets corresponding token_management_enabled property in the Manifest Schema as true for runOnSlack: false apps. 

Samples with `tokenManagementEnabled` field should also be updated. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
