### PR TITLE
Remove some deprecated items

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -171,12 +171,6 @@ export type BaseSlackFunctionHandler<
   | AsyncFunctionHandler<InputParameters, OutputParameters>
   | SyncFunctionHandler<InputParameters, OutputParameters>;
 
-// Exporting this alias for backwards compatability
-/**
- * @deprecated Use either SlackFunctionHandler<Definition> or BaseSlackFunctionHandler<Inputs, Outputs>
- */
-export type FunctionHandler<I, O> = BaseSlackFunctionHandler<I, O>;
-
 type SuccessfulFunctionReturnArgs<
   OutputParameters extends FunctionParameters,
 > = {

--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -196,24 +196,6 @@ Deno.test("Manifest() properly converts name to proper key", () => {
   assertEquals(manifest.types, { "Using Name": { type: "boolean" } });
 });
 
-Deno.test("Manifest() properly converts callback_id to proper key", () => {
-  const UsingCallback = DefineType({
-    callback_id: "Using Callback",
-    type: Schema.types.boolean,
-  });
-
-  const definition: SlackManifestType = {
-    name: "Name",
-    description: "Description",
-    icon: "icon.png",
-    longDescription: "LongDescription",
-    botScopes: [],
-    types: [UsingCallback],
-  };
-  const manifest = Manifest(definition);
-  assertEquals(manifest.types, { "Using Callback": { type: "boolean" } });
-});
-
 Deno.test("Manifest() always sets token_management_enabled to false for runOnSlack: true apps", () => {
   // When runOnSlack is explicitly specified as true, token_management_enabled must be set to false
   const definition: SlackManifestType = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 export type {
   BaseSlackFunctionHandler,
   BlockActionHandler,
-  FunctionHandler, // Deprecated
   SlackFunctionHandler,
 } from "./functions/types.ts";
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -23,7 +23,7 @@ export class CustomType<Def extends CustomTypeDefinition>
   constructor(
     public definition: Def,
   ) {
-    this.id = "name" in definition ? definition.name : definition.callback_id;
+    this.id = definition.name;
     this.definition = definition;
     this.description = definition.description;
     this.title = definition.title;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -59,13 +59,8 @@ export class CustomType<Def extends CustomTypeDefinition>
     }
   }
   export(): ManifestCustomTypeSchema {
-    // remove callback_id or name from the definition we pass to the manifest
-    if ("name" in this.definition) {
-      const { name: _n, ...definition } = this.definition;
-      return definition;
-    } else {
-      const { callback_id: _c, ...definition } = this.definition;
-      return definition;
-    }
+    // remove name from the definition we pass to the manifest
+    const { name: _n, ...definition } = this.definition;
+    return definition;
   }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,21 +3,12 @@ import { SlackManifest } from "../manifest/mod.ts";
 import { ManifestCustomTypeSchema } from "../manifest/manifest_schema.ts";
 import { CustomType } from "./mod.ts";
 
-export type NameTypeDefinition =
+export type CustomTypeDefinition =
   & { name: string }
   & TypedParameterDefinition;
-export type CallbackTypeDefinition =
-  & { callback_id: string }
-  & TypedParameterDefinition;
-
-export type CustomTypeDefinition = NameTypeDefinition | CallbackTypeDefinition;
 
 export type DefineTypeFunction = {
-  <Def extends NameTypeDefinition>(definition: Def): CustomType<Def>;
-  /**
-   * @deprecated Use name instead of callback_id
-   */
-  <Def extends CallbackTypeDefinition>(definition: Def): CustomType<Def>;
+  <Def extends CustomTypeDefinition>(definition: Def): CustomType<Def>;
 };
 
 export interface ICustomType {

--- a/src/types/types_test.ts
+++ b/src/types/types_test.ts
@@ -12,30 +12,6 @@ Deno.test("DefineType test against id using the name parameter", () => {
   assertEquals(Type.id, "Name");
 });
 
-Deno.test("DefineType test against id using the callback_id parameter", () => {
-  const Type = DefineType({
-    title: "Title",
-    description: "Description",
-    callback_id: "Callback_id",
-    type: "Type",
-  });
-
-  assertEquals(Type.id, "Callback_id");
-});
-
-Deno.test("DefineType test toString using the callback_id parameter", () => {
-  const Type = DefineType({
-    title: "Title",
-    description: "Description",
-    callback_id: "Callback_id",
-    type: "Type",
-  });
-
-  const typeString = Type.toString();
-
-  assertEquals(typeString, "#/types/Callback_id");
-});
-
 Deno.test("DefineType test toString using the name parameter", () => {
   const Type = DefineType({
     title: "Title",
@@ -54,23 +30,6 @@ Deno.test("DefineType test export using the name parameter", () => {
     title: "Title",
     description: "Description",
     name: "Name",
-    type: "Type",
-  });
-
-  const exportType = Type.export();
-
-  assertEquals(exportType, {
-    title: "Title",
-    description: "Description",
-    type: "Type",
-  });
-});
-
-Deno.test("DefineType test export using the callback_id parameter", () => {
-  const Type = DefineType({
-    title: "Title",
-    description: "Description",
-    callback_id: "Callback_id",
     type: "Type",
   });
 


### PR DESCRIPTION
###  Summary

This removes 2 deprecated items:

* Top level `FunctionHandler` export that was replaced with `SlackFunctionHandler` type.
* CustomType definitions support for `callback_id` that was replaced with `name`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
