### PR TITLE
fixing SlackFunctionType union

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -268,30 +268,32 @@ export type FunctionDefinitionArgs<
 };
 
 export type SlackFunctionType<Definition> = Definition extends
-  FunctionDefinitionArgs<infer I, infer O, infer RI, infer RO> ? {
-    (): SlackFunctionHandler<Definition>;
-    addBlockActionsHandler(
-      actionConstraint: BlockActionConstraint,
-      handler: BlockActionHandler<
-        FunctionDefinitionArgs<I, O, RI, RO>
-      >,
-    ): SlackFunctionType<Definition>;
-    addViewClosedHandler(
-      viewConstraint: BasicConstraintField,
-      handler: ViewClosedHandler<
-        FunctionDefinitionArgs<I, O, RI, RO>
-      >,
-    ): SlackFunctionType<Definition>;
-    addViewSubmissionHandler(
-      viewConstraint: BasicConstraintField,
-      handler: ViewSubmissionHandler<
-        FunctionDefinitionArgs<I, O, RI, RO>
-      >,
-    ): SlackFunctionType<Definition>;
-    addUnhandledEventHandler(
-      handler: UnhandledEventHandler<
-        FunctionDefinitionArgs<I, O, RI, RO>
-      >,
-    ): SlackFunctionType<Definition>;
-  }
+  FunctionDefinitionArgs<infer I, infer O, infer RI, infer RO> ? (
+    & SlackFunctionHandler<Definition>
+    & {
+      addBlockActionsHandler(
+        actionConstraint: BlockActionConstraint,
+        handler: BlockActionHandler<
+          FunctionDefinitionArgs<I, O, RI, RO>
+        >,
+      ): SlackFunctionType<Definition>;
+      addViewClosedHandler(
+        viewConstraint: BasicConstraintField,
+        handler: ViewClosedHandler<
+          FunctionDefinitionArgs<I, O, RI, RO>
+        >,
+      ): SlackFunctionType<Definition>;
+      addViewSubmissionHandler(
+        viewConstraint: BasicConstraintField,
+        handler: ViewSubmissionHandler<
+          FunctionDefinitionArgs<I, O, RI, RO>
+        >,
+      ): SlackFunctionType<Definition>;
+      addUnhandledEventHandler(
+        handler: UnhandledEventHandler<
+          FunctionDefinitionArgs<I, O, RI, RO>
+        >,
+      ): SlackFunctionType<Definition>;
+    }
+  )
   : never;


### PR DESCRIPTION
###  Summary

This fixes a bug in the `SlackFunctionType` to use a union instead of the incorrect usage of a function w/ a return arg of type  `SlackFunctionHandler`. This causes a bug when trying to import and use the export in a unit test w/ the `SlackFunctionTester`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
