### PR TITLE
Add developer education team as codeowner of docs dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @slackapi/denosaurs
+/docs/ @slackapi/developer-education


### PR DESCRIPTION
###  Summary

Add developer education team as codeowner of docs dir

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
