### PR TITLE
Revert "Fix parameter typing based on the discriminate union (#96)"

### DIFF
--- a/src/events/mod.ts
+++ b/src/events/mod.ts
@@ -57,7 +57,6 @@ export class CustomEvent<Def extends CustomEventDefinition>
   export(): ManifestCustomEventSchema {
     // remove name from the definition we pass to the manifest
     const { name: _n, ...definition } = this.definition;
-    // Using JSON.stringify to force any custom types into their string reference
-    return JSON.parse(JSON.stringify(definition));
+    return definition;
   }
 }

--- a/src/parameters/mod.ts
+++ b/src/parameters/mod.ts
@@ -8,7 +8,6 @@ import type {
 import { ParamReference } from "./param.ts";
 import { WithUntypedObjectProxy } from "./with-untyped-object-proxy.ts";
 import SchemaTypes from "../schema/schema_types.ts";
-import { CustomType } from "../types/mod.ts";
 
 export type ParameterDefinition = TypedParameterDefinition;
 
@@ -69,8 +68,8 @@ export const ParameterVariable = <P extends ParameterDefinition>(
 ): ParameterVariableType<P> => {
   let param: ParameterVariableType<P> | null = null;
 
-  if (definition.type instanceof CustomType) {
-    //@ts-expect-error this is hitting an excessively deep or infinite depth error
+  // TODO: Should be able to use instanceof CustomType here
+  if (definition.type instanceof Object) {
     param = ParameterVariable(
       namespace,
       paramName,

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -12,14 +12,13 @@ export type PrimitiveParameterDefinition =
   | TypedArrayParameterDefinition;
 
 export type TypedParameterDefinition =
-  | CustomTypeParameterDefinition
   | TypedObjectParameterDefinition
   | UntypedObjectParameterDefinition
   | PrimitiveParameterDefinition
   | OAuth2ParameterDefinition;
 
 export type CustomTypeParameterDefinition =
-  & Omit<BaseParameterDefinition<AllValues>, "type">
+  & BaseParameterDefinition<AllValues>
   & {
     type: ICustomType;
   };
@@ -27,7 +26,7 @@ export type CustomTypeParameterDefinition =
 // A type is either a string, or a Custom Type!
 type BaseParameterDefinition<T> = {
   /** Defines the parameter type. */
-  type: string;
+  type: string | ICustomType;
   /** An optional parameter title. */
   title?: string;
   /** An optional parameter description. */
@@ -59,9 +58,7 @@ export type TypedObjectParameterDefinition =
     additionalProperties?: boolean;
     /** Object defining what properties are allowed on the parameter. */
     properties: {
-      [key: string]:
-        | PrimitiveParameterDefinition
-        | CustomTypeParameterDefinition;
+      [key: string]: PrimitiveParameterDefinition;
     };
   };
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -61,7 +61,6 @@ export class CustomType<Def extends CustomTypeDefinition>
   export(): ManifestCustomTypeSchema {
     // remove name from the definition we pass to the manifest
     const { name: _n, ...definition } = this.definition;
-    // Using JSON.stringify to force any custom types into their string reference
-    return JSON.parse(JSON.stringify(definition));
+    return definition;
   }
 }


### PR DESCRIPTION
This reverts commit 895e3d9484eeb720a6e6d118bc13960b6649b332.

###  Summary
Reverts this "fix"

### Testing
This commit introduced a bug where two workflows with parameters being used will result in an infinite loop error. Verify that using two workflows with parameters will not lead to an error.

Note that this reintroduces the issue where Parameters aren't properly typed based on the value provided to the `type` property.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
