### PR TITLE
Adding a test for multiple workflows passed into Manifest()

### DIFF
--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -958,3 +958,41 @@ Deno.test("SlackManifest() oauth2 providers are undefined when not configured", 
   assertEquals(definition.externalAuthProviders, undefined);
   assertEquals(exportedManifest.external_auth_providers, undefined);
 });
+
+Deno.test("Manifest supports multiple workflows with parameters", () => {
+  const workflow1 = DefineWorkflow({
+    callback_id: "test",
+    title: "test",
+    input_parameters: {
+      properties: {
+        one: {
+          type: Schema.types.string,
+        },
+      },
+      required: ["one"],
+    },
+  });
+
+  const workflow2 = DefineWorkflow({
+    callback_id: "test2",
+    title: "test",
+    input_parameters: {
+      properties: {
+        one: {
+          type: Schema.types.string,
+        },
+      },
+      required: ["one"],
+    },
+  });
+
+  const manifest = Manifest({
+    name: "Name",
+    description: "Description",
+    botScopes: [],
+    icon: "icon.png",
+    workflows: [workflow1, workflow2],
+  });
+
+  assertEquals(Object.keys(manifest.workflows || {}).length, 2);
+});


### PR DESCRIPTION
###  Summary

Adds a test to ensure there are no errors when passing two workflows with input parameters into `Manifest()` 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
