### PR TITLE
HERMES-3573: Add type to `body.message` Block Action handler argument

### DIFF
--- a/src/functions/interactivity/block_actions_types.ts
+++ b/src/functions/interactivity/block_actions_types.ts
@@ -73,12 +73,12 @@ export type BlockActionsBody = {
      * @description {@link https://api.slack.com/metadata Message metadata}, if any was attached to the message.
      */
     metadata?: {
-      event_type: string,
+      event_type: string;
       event_payload: {
         // deno-lint-ignore no-explicit-any
         [key: string]: any;
-      }
-    }
+      };
+    };
     /**
      * @description Total number of replies in the {@link https://api.slack.com/messaging/managing#threading thread}.
      */
@@ -100,7 +100,7 @@ export type BlockActionsBody = {
      * contain the fallback text to display in constrained UIs (like notifications) or in screenreaders. See
      * {@link https://api.slack.com/methods/chat.postMessage#blocks_and_attachments the API documentation for use of text, blocks and attachments in messages}.
      */
-    text: string,
+    text: string;
     /**
      * @description Timestamp of the parent message. If the message is already a parent message, then this value will equal the `ts` value. Use this value if you want to post a message as a {@link https://api.slack.com/messaging/managing#threading threaded reply} to a particular message.
      */
@@ -108,16 +108,16 @@ export type BlockActionsBody = {
     /**
      * @description Timestamp of the message.
      */
-    ts: string,
+    ts: string;
     /**
      * @description The type of message. This is always "message."
      */
-    type: "message",
+    type: "message";
     /**
      * @description Encoded user ID of the user that posted the message, e.g. U123456.
      */
-    user: string,
-  },
+    user: string;
+  };
   response_url: string;
   /**
    * @description The workspace, or team, details the Block Kit interaction originated from.

--- a/src/functions/interactivity/block_actions_types.ts
+++ b/src/functions/interactivity/block_actions_types.ts
@@ -156,8 +156,17 @@ export type BlockActionsBody = {
   };
   // deno-lint-ignore no-explicit-any
   [key: string]: any;
-  /* Other properties seen on this type that should be added at some point:
-   * container: {}; // should be a reference to message or view below, depending on the container for the block kit interactive componenet
+  /* TODO: Other properties seen on this type that should be added at some point:
+   * container: {}; // should be a reference to message or view, depending on the container for the block kit interactive componenet
+   * message container looks like:
+   *  "container": {
+        "type": "message",
+        "message_ts": "1663103912.870299",
+        "channel_id": "C03DS3P5ED6",
+        "is_ephemeral": false
+      },
+      view container looks like:
+      container: { type: "view", view_id: "V041UDW806B" }
    * view: {}; // if the block kit interactive component was part of a view, details for the view are here
    * state: { values: {}}; // seen but usually empty?
    */

--- a/src/functions/interactivity/block_actions_types.ts
+++ b/src/functions/interactivity/block_actions_types.ts
@@ -47,6 +47,57 @@ export type BlockActionsBody = {
    * @description Whether this event originated from a workspace that is part of an enterprise installation.
    */
   is_enterprise_install: boolean;
+  /**
+   * @description Information about the source message this Block Action interaction originated from.
+   * This may be optional in the case that the Block Action interaction originated from a view rather than a message.
+   */
+  // TODO: maybe factor this into own type once we need to re-use?
+  message?: {
+    /**
+     * @description The encoded application ID the event was dispatched to, e.g. A123456.
+     */
+    app_id: string;
+    /**
+     * @description The Block Kit elements included in the message.
+     */
+    blocks: BlockElement[];
+    /**
+     * @description Message metadata, if any was attached to the message.
+     */
+    metadata?: {
+      event_type: string,
+      event_payload: {
+        // deno-lint-ignore no-explicit-any
+        [key: string]: any;
+      }
+    }
+    /**
+     * @description Encoded team ID, e.g. T123456.
+     */
+    team: string;
+    /**
+     * @description The text in the message. If the message was composed of Block Kit elements, this property would
+     * contain the fallback text to display in constrained UIs (like notifications) or in screenreaders. See
+     * {@link https://api.slack.com/methods/chat.postMessage#blocks_and_attachments the API documentation for use of text, blocks and attachments in messages}.
+     */
+    text: string,
+    /**
+     * @description Timestamp of the parent message. If the message is already a parent message, then this value will equal the `ts` value. Use this value if you want to post a message as a {@link https://api.slack.com/messaging/managing#threading threaded reply} to a particular message.
+     */
+    thread_ts: string;
+    /**
+     * @description Timestamp of the message.
+     */
+    ts: string,
+    /**
+     * @description The type of message. This is always "message."
+     */
+    type: "message",
+    /**
+     * @description Encoded user ID of the user that posted the message, e.g. U123456.
+     */
+    user: string,
+  },
   response_url: string;
   /**
    * @description The workspace, or team, details the Block Kit interaction originated from.
@@ -87,8 +138,7 @@ export type BlockActionsBody = {
   [key: string]: any;
   /* Other properties seen on this type that should be added at some point:
    * container: {}; // should be a reference to message or view below, depending on the container for the block kit interactive componenet
-   * message: {}; // if the block kit interactive componnet was part of a message, details for the message are here
-   * view: {}; // if the block kit interactive componnet was part of a view, details for the view are here
+   * view: {}; // if the block kit interactive component was part of a view, details for the view are here
    * state: { values: {}}; // seen but usually empty?
    */
 };

--- a/src/functions/interactivity/block_actions_types.ts
+++ b/src/functions/interactivity/block_actions_types.ts
@@ -5,6 +5,7 @@ Some other references that may be useful to fill this out:
 - https://api.slack.com/changelog/2020-09-full-state-on-view-submisson-and-block-actions
 - https://api.slack.com/reference/interaction-payloads/block-actions#fields
 - https://github.com/slackapi/bolt-js/blob/main/src/types/actions/block-action.ts
+- https://api.slack.com/changelog/2018-05-file-threads-soon-tread
 */
 
 /**
@@ -51,18 +52,25 @@ export type BlockActionsBody = {
    * @description Information about the source message this Block Action interaction originated from.
    * This may be optional in the case that the Block Action interaction originated from a view rather than a message.
    */
-  // TODO: maybe factor this into own type once we need to re-use?
   message?: {
     /**
      * @description The encoded application ID the event was dispatched to, e.g. A123456.
      */
     app_id: string;
     /**
-     * @description The Block Kit elements included in the message.
+     * @description The {@link https://api.slack.com/block-kit Block Kit} elements included in the message.
      */
     blocks: BlockElement[];
     /**
-     * @description Message metadata, if any was attached to the message.
+     * @description Whether the {@link https://api.slack.com/messaging/managing#threading thread} has been locked.
+     */
+    is_locked: boolean;
+    /**
+     * @description If the {@link https://api.slack.com/messaging/managing#threading thread} has at least one reply, points to the most recent reply's `ts` value.
+     */
+    latest_reply?: string;
+    /**
+     * @description {@link https://api.slack.com/metadata Message metadata}, if any was attached to the message.
      */
     metadata?: {
       event_type: string,
@@ -71,6 +79,18 @@ export type BlockActionsBody = {
         [key: string]: any;
       }
     }
+    /**
+     * @description Total number of replies in the {@link https://api.slack.com/messaging/managing#threading thread}.
+     */
+    reply_count: number;
+    /**
+     * @description Array of up to 5 encoded user IDs (i.e. U12345) that replied in the {@link https://api.slack.com/messaging/managing#threading thread}.
+     */
+    reply_users: string[];
+    /**
+     * @description Total number of users that replied in the {@link https://api.slack.com/messaging/managing#threading thread}.
+     */
+    reply_users_count: number;
     /**
      * @description Encoded team ID, e.g. T123456.
      */

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -73,7 +73,7 @@ type FunctionInputRuntimeType<
         Param["type"]["definition"],
         IncreaseDepth<CurrentDepth>
       >
-    // Not a Custom Type, so assign the runtime value
+      // Not a Custom Type, so assign the runtime value
     : Param["type"] extends typeof SchemaTypes.string ? string
     : Param["type"] extends
       | typeof SchemaTypes.integer

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -73,7 +73,7 @@ type FunctionInputRuntimeType<
         Param["type"]["definition"],
         IncreaseDepth<CurrentDepth>
       >
-      // Not a Custom Type, so assign the runtime value
+    // Not a Custom Type, so assign the runtime value
     : Param["type"] extends typeof SchemaTypes.string ? string
     : Param["type"] extends
       | typeof SchemaTypes.integer


### PR DESCRIPTION
###  Summary

Adding typing to Block Kit action handler's `body.message` property. Tried to document where I was able to find resources on the subject. Sort of a random conglomeration; might not be exactly correct based on the various contexts that the shape of these payloads tend to change: enterprise grid vs. non-grid workspace, message vs. view container for block kit, to name a few that I know of.