### PR TITLE
[HERMES-3842] Add npm build action

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,31 @@
+# This workflow runs a test build for npm against changes on main or PRs
+
+name: Npm Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    
+    steps:
+      - name: Actions checkout
+        uses: actions/checkout@v3
+      
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: latest
+          registry-url: https://registry.npmjs.org/
+          
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Run build_npm.ts
+        run: deno run -A build_npm.ts


### PR DESCRIPTION
###  Summary

Adds a git action that runs the build_npm.ts script on PRs and commits to `main`. 

The Npm Build step this adds should fail currently, this is expected. A [separate PR](https://github.com/slackapi/deno-slack-sdk/pull/107) will fix the issues causing the action failure.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
