### PR TITLE
[HERMES-3843] Shim deno fetch api for npm build

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,31 @@
+# This workflow runs a test build for npm against changes on main or PRs
+
+name: Npm Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    
+    steps:
+      - name: Actions checkout
+        uses: actions/checkout@v3
+      
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: latest
+          registry-url: https://registry.npmjs.org/
+          
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Run build_npm.ts
+        run: deno run -A build_npm.ts

--- a/build_npm.ts
+++ b/build_npm.ts
@@ -7,6 +7,10 @@ await build({
   typeCheck: false,
   entryPoints: ["./src/mod.ts"],
   outDir: "./npm",
+  // ensures that the emitted package is compatible with node v14 later
+  compilerOptions: {
+    target: "ES2020"
+  },
   shims: {
     // see JS docs for overview and more options
     deno: true,

--- a/build_npm.ts
+++ b/build_npm.ts
@@ -13,9 +13,9 @@ await build({
     // custom shims
     custom: [{
       package: {
-        name: "node-fetch-commonjs",
+        name: "node-fetch",
         // Please see: https://www.npmjs.com/package/node-fetch-commonjs
-        version: "~3.1.1", 
+        version: "2.6.7", 
       },
       globalNames: [{
         name: "fetch",

--- a/build_npm.ts
+++ b/build_npm.ts
@@ -4,11 +4,24 @@ import { build, emptyDir } from "https://deno.land/x/dnt/mod.ts";
 await emptyDir("./npm");
 
 await build({
+  typeCheck: false,
   entryPoints: ["./src/mod.ts"],
   outDir: "./npm",
   shims: {
     // see JS docs for overview and more options
     deno: true,
+    // custom shims
+    custom: [{
+      package: {
+        name: "node-fetch-commonjs",
+        // Please see: https://www.npmjs.com/package/node-fetch-commonjs
+        version: "~3.1.1", 
+      },
+      globalNames: [{
+        name: "fetch",
+        exportName: "default"
+      }]
+    }],
   },
   package: {
     // package.json properties


### PR DESCRIPTION
###  Summary

@fil discovered that - `build_npm.ts` which uses `dnt` package to build deno modules for npm distribution - was failing due to some recent changes that added deno-slack-api as an overall project dependency.

This PR resolves that issue by adding a polyfill for that dependency. 

Related to [this PR](https://github.com/slackapi/deno-slack-sdk/pull/106) which adds an extra check on PRs to main to run the build. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
