### PR TITLE
Add FunctionSourceFile as an easy way to configure source_file in DefineFunction

### DIFF
--- a/src/functions/function_source_file.ts
+++ b/src/functions/function_source_file.ts
@@ -1,0 +1,20 @@
+/**
+ * A factory function for easily generating DefineFunction's source_file parameter value.
+ *
+ * @param importMetaUrl the value of import.meta.url
+ * @param depth pass the depth when having nested directories under functions directory (default: 0)
+ * @returns a valid string value for DefineFunction's source_file argument
+ */
+const FunctionSourceFile = function (
+  // Pass the value of import.meta.url in a function code
+  importMetaUrl: string,
+  // If you have sub diretories under "functions" dir, set the depth.
+  // When you place functions/pto/data_submission.ts, the depth for the source file is 1.
+  depth = 0,
+): string {
+  const sliceStart = -2 - depth;
+  const path = new URL("", importMetaUrl).pathname;
+  return path.split("/").slice(sliceStart).join("/");
+};
+
+export default FunctionSourceFile;

--- a/src/functions/function_source_file_test.ts
+++ b/src/functions/function_source_file_test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "../dev_deps.ts";
+import { FunctionSourceFile, Schema } from "../mod.ts";
+import { DefineFunction } from "./mod.ts";
+
+Deno.test("FunctionSourceFile returns a valid source_file", () => {
+  const sourceFile = FunctionSourceFile(
+    "file:///path-to-project-dir/functions/hello_world.ts",
+  );
+  assertEquals(sourceFile, "functions/hello_world.ts");
+});
+
+Deno.test("FunctionSourceFile returns a valid source_file when depth is given", () => {
+  const sourceFile = FunctionSourceFile(
+    "file:///path-to-project-dir/functions/approval/iteractivity_handler.ts",
+    1,
+  );
+  assertEquals(sourceFile, "functions/approval/iteractivity_handler.ts");
+});
+
+Deno.test("FunctionSourceFile returns a valid string for this test file", () => {
+  const sourceFile = FunctionSourceFile(import.meta.url);
+  assertEquals(sourceFile, "functions/function_source_file_test.ts");
+});
+
+Deno.test("FunctionSourceFile can be used for DefineFunction", () => {
+  const def = DefineFunction({
+    callback_id: "test-callback",
+    title: "Test function",
+    source_file: FunctionSourceFile(import.meta.url),
+    input_parameters: {
+      properties: {
+        name: { type: Schema.types.string },
+        channel: { type: Schema.slack.types.channel_id },
+      },
+      required: [],
+    },
+    output_parameters: {
+      properties: {},
+      required: [],
+    },
+  });
+  assertEquals(
+    def.definition.source_file,
+    "functions/function_source_file_test.ts",
+  );
+});

--- a/src/functions/function_source_file_test.ts
+++ b/src/functions/function_source_file_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../dev_deps.ts";
+import { assertMatch } from "../dev_deps.ts";
 import { FunctionSourceFile, Schema } from "../mod.ts";
 import { DefineFunction } from "./mod.ts";
 
@@ -6,7 +6,8 @@ Deno.test("FunctionSourceFile returns a valid source_file", () => {
   const sourceFile = FunctionSourceFile(
     "file:///path-to-project-dir/functions/hello_world.ts",
   );
-  assertEquals(sourceFile, "functions/hello_world.ts");
+  // .js for npm builds
+  assertMatch(sourceFile, new RegExp("functions/hello_world.(ts|js)"));
 });
 
 Deno.test("FunctionSourceFile returns a valid source_file when depth is given", () => {
@@ -14,12 +15,20 @@ Deno.test("FunctionSourceFile returns a valid source_file when depth is given", 
     "file:///path-to-project-dir/functions/approval/iteractivity_handler.ts",
     1,
   );
-  assertEquals(sourceFile, "functions/approval/iteractivity_handler.ts");
+  // .js for npm builds
+  assertMatch(
+    sourceFile,
+    new RegExp("functions/approval/iteractivity_handler.(ts|js)"),
+  );
 });
 
 Deno.test("FunctionSourceFile returns a valid string for this test file", () => {
   const sourceFile = FunctionSourceFile(import.meta.url);
-  assertEquals(sourceFile, "functions/function_source_file_test.ts");
+  // .js for npm builds
+  assertMatch(
+    sourceFile,
+    new RegExp("functions/function_source_file_test.(ts|js)"),
+  );
 });
 
 Deno.test("FunctionSourceFile can be used for DefineFunction", () => {
@@ -39,8 +48,9 @@ Deno.test("FunctionSourceFile can be used for DefineFunction", () => {
       required: [],
     },
   });
-  assertEquals(
+  // .js for npm builds
+  assertMatch(
     def.definition.source_file,
-    "functions/function_source_file_test.ts",
+    new RegExp("functions/function_source_file_test.(ts|js)"),
   );
 });

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,6 +6,7 @@ export type {
 } from "./manifest/types.ts";
 export type { ManifestSchema } from "./manifest/manifest_schema.ts";
 export { DefineFunction } from "./functions/mod.ts";
+export { default as FunctionSourceFile } from "./functions/function_source_file.ts";
 export { SlackFunction } from "./functions/slack-function.ts";
 export {
   BlockActionsRouter,


### PR DESCRIPTION
###  Summary

This pull request adds a new utility that enables developers to easily configure the "source_file" argument in `DefineFunction`. Specifically, you can use it in the following way. 

```typescript
import { DefineFunction, FunctionSourceFile, Schema } from "deno-slack-sdk/mod.ts";

const def = DefineFunction({
  callback_id: "hello-world",
  title: "Hello world function",
  // This resolves "functions/hello_world.ts" for you
  // When you rename the file, the value can be automatically changed
  source_file: FunctionSourceFile(import.meta.url),
  input_parameters: { properties: { channel: { type: Schema.slack.types.channel_id } }, required: [] },
  output_parameters: { properties: {}, required: [] },
})
```

As mentioned in the comment in the above code, the benefit of this is that you don't need to update the string when you rename the function source file name. Let's say a developer started with `hello_world.ts` in the beginning, and then the dev renamed it to a more realistic one like `create_channel.ts`. In this case, updating the source_file part in code is necessary too. Contrarily, if the dev goes with this `FunctionSourceFile`, the dev no longer needs to modify any parts of the code just because of renaming a file.

Discussion points in reviews:
* What do we think about the name `FunctionSourceFile`? Any good alternative?
* Can the SDK automatically resolve the file path and allow developers to skip the argument? Perhaps, it's not feasible. IIUC, there is no way to get the file path of a method caller on the callee side.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
