### PR TITLE
Update type parameters to be compatible with Deno 1.26 breaking changes

### DIFF
--- a/src/functions/interactivity/action_router_test.ts
+++ b/src/functions/interactivity/action_router_test.ts
@@ -8,7 +8,10 @@ import {
 import { BlockActionsRouter } from "./action_router.ts";
 import type { ActionContext } from "./types.ts";
 import type { BlockAction } from "./block_actions_types.ts";
-import type { FunctionRuntimeParameters } from "../types.ts";
+import type {
+  FunctionParameters,
+  FunctionRuntimeParameters,
+} from "../types.ts";
 import type {
   ParameterSetDefinition,
   PossibleParameterKeys,
@@ -19,7 +22,7 @@ import { DefineFunction, Schema } from "../../mod.ts";
 // Helper test types
 // TODO: maybe we want to export this for userland usage at some point?
 // Very much a direct copy from the existing main function tester types and utilties in src/functions/tester
-type SlackActionHandlerTesterArgs<InputParameters> =
+type SlackActionHandlerTesterArgs<InputParameters extends FunctionParameters> =
   & Partial<
     ActionContext<InputParameters>
   >

--- a/src/functions/interactivity/types.ts
+++ b/src/functions/interactivity/types.ts
@@ -49,23 +49,25 @@ export type UnhandledEventHandler<Definition> = Definition extends
   }
   : never;
 
-export type BaseInteractivityContext<InputParameters> =
+export type BaseInteractivityContext<
+  InputParameters extends FunctionParameters,
+> =
   & BaseRuntimeFunctionContext<InputParameters>
   & FunctionContextEnrichment;
 
-export type ActionContext<InputParameters> =
+export type ActionContext<InputParameters extends FunctionParameters> =
   & BaseInteractivityContext<InputParameters>
   & ActionSpecificContext<InputParameters>;
 
-export type ViewSubmissionContext<InputParameters> =
+export type ViewSubmissionContext<InputParameters extends FunctionParameters> =
   & BaseInteractivityContext<InputParameters>
   & ViewSubmissionSpecificContext<InputParameters>;
 
-export type ViewClosedContext<InputParameters> =
+export type ViewClosedContext<InputParameters extends FunctionParameters> =
   & BaseInteractivityContext<InputParameters>
   & ViewClosedSpecificContext<InputParameters>;
 
-export type UnhandledEventContext<InputParameters> =
+export type UnhandledEventContext<InputParameters extends FunctionParameters> =
   & BaseInteractivityContext<
     InputParameters
   >
@@ -156,14 +158,18 @@ export type ViewConstraintObject = {
 export type BasicConstraintField = string | string[] | RegExp;
 
 // -- These types represent the deno-slack-runtime function handler interfaces
-export type RuntimeActionContext<InputParameters> =
+export type RuntimeActionContext<InputParameters extends FunctionParameters> =
   & BaseRuntimeFunctionContext<InputParameters>
   & ActionSpecificContext<InputParameters>;
 
-export type RuntimeViewSubmissionContext<InputParameters> =
+export type RuntimeViewSubmissionContext<
+  InputParameters extends FunctionParameters,
+> =
   & BaseRuntimeFunctionContext<InputParameters>
   & ViewSubmissionSpecificContext<InputParameters>;
 
-export type RuntimeViewClosedContext<InputParameters> =
+export type RuntimeViewClosedContext<
+  InputParameters extends FunctionParameters,
+> =
   & BaseRuntimeFunctionContext<InputParameters>
   & ViewClosedSpecificContext<InputParameters>;

--- a/src/functions/interactivity/view_router_test.ts
+++ b/src/functions/interactivity/view_router_test.ts
@@ -15,6 +15,7 @@ import type {
 import type { View } from "./view_types.ts";
 import type {
   FunctionDefinitionArgs,
+  FunctionParameters,
   FunctionRuntimeParameters,
 } from "../types.ts";
 import type {
@@ -27,7 +28,9 @@ import { DefineFunction, Schema } from "../../mod.ts";
 // Helper test types
 // TODO: maybe we want to export this for userland usage at some point?
 // Very much a direct copy from the existing main function tester types and utilties in src/functions/tester
-type SlackViewSubmissionHandlerTesterArgs<InputParameters> =
+type SlackViewSubmissionHandlerTesterArgs<
+  InputParameters extends FunctionParameters,
+> =
   & Partial<
     ViewSubmissionContext<InputParameters>
   >
@@ -35,7 +38,9 @@ type SlackViewSubmissionHandlerTesterArgs<InputParameters> =
     inputs: InputParameters;
   };
 
-type SlackViewClosedHandlerTesterArgs<InputParameters> =
+type SlackViewClosedHandlerTesterArgs<
+  InputParameters extends FunctionParameters,
+> =
   & Partial<
     ViewClosedContext<InputParameters>
   >

--- a/src/functions/tester/types.ts
+++ b/src/functions/tester/types.ts
@@ -3,10 +3,14 @@ import type {
   PossibleParameterKeys,
 } from "../../parameters/mod.ts";
 import type { SlackFunctionDefinition } from "../mod.ts";
-import type { FunctionContext, FunctionRuntimeParameters } from "../types.ts";
+import type {
+  FunctionContext,
+  FunctionParameters,
+  FunctionRuntimeParameters,
+} from "../types.ts";
 
 export type SlackFunctionTesterArgs<
-  InputParameters,
+  InputParameters extends FunctionParameters,
 > =
   & Partial<
     FunctionContext<InputParameters>
@@ -58,7 +62,9 @@ export type SlackFunctionTesterFn = {
   // Accept a string
   (funcOrCallbackId: string): {
     createContext: {
-      <I>(args: SlackFunctionTesterArgs<I>): FunctionContext<I>;
+      <I extends FunctionParameters>(
+        args: SlackFunctionTesterArgs<I>,
+      ): FunctionContext<I>;
     };
   };
 };

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -140,8 +140,8 @@ export type FunctionRuntimeParameters<
   };
 
 type AsyncFunctionHandler<
-  InputParameters,
-  OutputParameters,
+  InputParameters extends FunctionParameters,
+  OutputParameters extends FunctionParameters,
   Context extends BaseRuntimeFunctionContext<InputParameters>,
 > = {
   (
@@ -150,8 +150,8 @@ type AsyncFunctionHandler<
 };
 
 type SyncFunctionHandler<
-  InputParameters,
-  OutputParameters,
+  InputParameters extends FunctionParameters,
+  OutputParameters extends FunctionParameters,
   Context extends BaseRuntimeFunctionContext<InputParameters>,
 > = {
   (
@@ -231,7 +231,7 @@ type SuccessfulFunctionReturnArgs<
   error?: string;
 };
 
-type ErroredFunctionReturnArgs<OutputParameters> =
+type ErroredFunctionReturnArgs<OutputParameters extends FunctionParameters> =
   & Partial<SuccessfulFunctionReturnArgs<OutputParameters>>
   & Required<Pick<SuccessfulFunctionReturnArgs<OutputParameters>, "error">>;
 
@@ -242,7 +242,7 @@ type PendingFunctionReturnArgs = {
 };
 
 export type FunctionHandlerReturnArgs<
-  OutputParameters,
+  OutputParameters extends FunctionParameters,
 > =
   | SuccessfulFunctionReturnArgs<OutputParameters>
   | ErroredFunctionReturnArgs<OutputParameters>


### PR DESCRIPTION
###  Summary

This pull request resolves the compilation errors due to Deno 1.26 breaking changes. Once the changes in this PR land, the CI builds for my PR https://github.com/slackapi/deno-slack-sdk/pull/109 should pass.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
