### PR TITLE
Expose enterprise_id to userland handlers.

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -123,6 +123,7 @@ that may be useful to leverage during your function's execution:
 - `client`: An API client ready for use in your function. An instance of the `deno-slack-api` library.
 - `token`: your application's access token.
 - `team_id`: the encoded team (a.k.a. Slack workspace) ID, i.e. T12345.
+- `enterprise_id`: the encoded enterprise ID, i.e. E12345. If the Slack workspace the function executes in is not a part of an enterprise grid, then this value will be the empty string (`""`).
 - `event`: an object containing the full incoming event details.
 
 ##### Function Return Object

--- a/src/functions/enrich-context_test.ts
+++ b/src/functions/enrich-context_test.ts
@@ -8,6 +8,7 @@ Deno.test("enrichContext with no env.SLACK_API_URL", () => {
     env: {},
     inputs: {},
     team_id: "team",
+    enterprise_id: "",
     token: "token",
   };
 
@@ -24,6 +25,7 @@ Deno.test("enrichContext with env.SLACK_API_URL", () => {
     },
     inputs: {},
     team_id: "team",
+    enterprise_id: "",
     token: "token",
   };
 

--- a/src/functions/interactivity/action_router_test.ts
+++ b/src/functions/interactivity/action_router_test.ts
@@ -140,6 +140,7 @@ const SlackActionHandlerTester: SlackActionHandlerTesterFn = <
       token,
       client: SlackAPI(token),
       team_id: args.team_id || "test-team-id",
+      enterprise_id: "",
       action: args.action || DEFAULT_ACTION,
       body: args.body || DEFAULT_BODY,
     };

--- a/src/functions/interactivity/view_router_test.ts
+++ b/src/functions/interactivity/view_router_test.ts
@@ -212,6 +212,7 @@ const SlackViewSubmissionHandlerTester: SlackViewSubmissionHandlerTesterFn = <
       view: args.view || DEFAULT_VIEW,
       body: args.body || DEFAULT_BODY,
       team_id: DEFAULT_VIEW.team_id,
+      enterprise_id: "",
     };
   };
 
@@ -282,6 +283,7 @@ const SlackViewClosedHandlerTester: SlackViewClosedHandlerTesterFn = <
       view: args.view || DEFAULT_VIEW,
       body: args.body || DEFAULT_BODY,
       team_id: DEFAULT_VIEW.team_id,
+      enterprise_id: "",
     };
   };
 

--- a/src/functions/tester/mod.ts
+++ b/src/functions/tester/mod.ts
@@ -51,6 +51,7 @@ export const SlackFunctionTester: SlackFunctionTesterFn = <
       token,
       client: SlackAPI(token),
       team_id: args.team_id || "test-team-id",
+      enterprise_id: args.enterprise_id || "test-enterprise-id",
       event: args.event || {
         type: "function_executed",
         event_ts: `${ts.getTime()}`,

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -269,6 +269,10 @@ export type BaseRuntimeFunctionContext<
    * @description A unique encoded ID representing the Slack team associated with the workspace where the function execution takes place.
    */
   team_id: string;
+  /**
+   * @description A unique encoded ID representing the Slack enterprise associated with the workspace where the function execution takes place. In a non-enterprise workspace, this value will be the empty string.
+   */
+  enterprise_id: string;
 };
 
 // SDK Function handlers receive these additional properties on the function context object


### PR DESCRIPTION
Relies on the work in https://github.com/slackapi/deno-slack-runtime/pull/38.

Exposes an `enterprise_id` property to all handlers.