### PR TITLE
Added message_ts and message_context

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -74,7 +74,8 @@ type FunctionInputRuntimeType<
       | typeof SlackSchemaTypes.user_id
       | typeof SlackSchemaTypes.usergroup_id
       | typeof SlackSchemaTypes.channel_id
-      | typeof SlackSchemaTypes.date ? string // Not a Custom Type, so assign the runtime value
+      | typeof SlackSchemaTypes.date
+      | typeof SlackSchemaTypes.message_ts ? string
     : Param["type"] extends
       | typeof SchemaTypes.integer
       | typeof SchemaTypes.number

--- a/src/schema/slack/types/custom/custom_slack_types_test.ts
+++ b/src/schema/slack/types/custom/custom_slack_types_test.ts
@@ -2,9 +2,10 @@ import { assertEquals } from "../../../../dev_deps.ts";
 import { CustomSlackTypes, InternalSlackTypes } from "./mod.ts";
 
 Deno.test("Custom Slack Types are stringified correctly", () => {
-  const { interactivity, user_context } = CustomSlackTypes;
+  const { interactivity, user_context, message_context } = CustomSlackTypes;
   const { form_input_object } = InternalSlackTypes;
   assertEquals(`${interactivity}`, interactivity.id);
   assertEquals(`${user_context}`, user_context.id);
+  assertEquals(`${message_context}`, message_context.id);
   assertEquals(`${form_input_object}`, form_input_object.id);
 });

--- a/src/schema/slack/types/custom/message_context.ts
+++ b/src/schema/slack/types/custom/message_context.ts
@@ -16,6 +16,7 @@ const MessageContextType = DefineType({
       type: SlackPrimitiveTypes.channel_id,
     },
   },
+  required: ["message_ts"],
 });
 
 export { MessageContextType };

--- a/src/schema/slack/types/custom/message_context.ts
+++ b/src/schema/slack/types/custom/message_context.ts
@@ -1,0 +1,21 @@
+import SchemaTypes from "../../../schema_types.ts";
+import { SlackPrimitiveTypes } from "../../types/mod.ts";
+import { DefineType } from "../../../../types/mod.ts";
+
+const MessageContextType = DefineType({
+  name: "slack#/types/message_context",
+  type: SchemaTypes.object,
+  properties: {
+    message_ts: {
+      type: SlackPrimitiveTypes.message_ts,
+    },
+    user_id: {
+      type: SlackPrimitiveTypes.user_id,
+    },
+    channel_id: {
+      type: SlackPrimitiveTypes.channel_id,
+    },
+  },
+});
+
+export { MessageContextType };

--- a/src/schema/slack/types/custom/mod.ts
+++ b/src/schema/slack/types/custom/mod.ts
@@ -1,10 +1,12 @@
 import { InteractivityType } from "./interactivity.ts";
 import { UserContextType } from "./user_context.ts";
 import { FormInput } from "./form_input.ts";
+import { MessageContextType } from "./message_context.ts";
 
 export const CustomSlackTypes = {
   interactivity: InteractivityType,
   user_context: UserContextType,
+  message_context: MessageContextType,
 };
 
 export const InternalSlackTypes = {

--- a/src/schema/slack/types/mod.ts
+++ b/src/schema/slack/types/mod.ts
@@ -7,7 +7,7 @@ const SlackPrimitiveTypes = {
   blocks: "slack#/types/blocks",
   oauth2: "slack#/types/credential/oauth2",
   rich_text: "slack#/types/rich_text",
-  message_ts: "string",
+  message_ts: "slack#/types/message_ts",
 } as const;
 
 export { SlackPrimitiveTypes };

--- a/src/schema/slack/types/mod.ts
+++ b/src/schema/slack/types/mod.ts
@@ -7,6 +7,7 @@ const SlackPrimitiveTypes = {
   blocks: "slack#/types/blocks",
   oauth2: "slack#/types/credential/oauth2",
   rich_text: "slack#/types/rich_text",
+  message_ts: "string",
 } as const;
 
 export { SlackPrimitiveTypes };

--- a/tests/integration/functions/function_handler_test.ts
+++ b/tests/integration/functions/function_handler_test.ts
@@ -750,6 +750,7 @@ Deno.test("Custom Function using a Custom Type input for a DefineProperty-wrappe
     };
   };
 });
+
 Deno.test("Custom Function using Slack's FormInput internal Custom Type input should provide correct typedobject typing in a function handler context", () => {
   const TestFunction = DefineFunction({
     callback_id: "my_callback_id",
@@ -796,6 +797,69 @@ Deno.test("Custom Function using Slack's FormInput internal Custom Type input sh
       true,
     );
     assert<CanBe<typeof formInput.elements, any[]>>(true);
+    
+    return {
+      outputs: inputs,
+    };
+  };
+
+  const { createContext } = SlackFunctionTester(TestFunction);
+
+  const result = validHandler(createContext({ inputs: sharedInputs }));
+});
+
+Deno.test("Custom Function using Slack's message-context Custom Type input should provide correct typedobject typing in a function handler context", () => {
+  const TestFunction = DefineFunction({
+    callback_id: "my_callback_id",
+    source_file: "test",
+    title: "Test",
+    input_parameters: {
+      properties: {
+        msgContext: {
+          type: Schema.slack.types.message_context,
+        },
+      },
+      required: ["msgContext"],
+    },
+    output_parameters: {
+      properties: {
+        msgContext: {
+          type: Schema.slack.types.message_context,
+        },
+      },
+      required: ["msgContext"],
+    },
+  });
+
+  const sharedInputs = {
+    msgContext: {
+      message_ts: "1234.567",
+      channel_id: "C12345"
+    }
+  };
+
+  const validHandler: EnrichedSlackFunctionHandler<
+    typeof TestFunction.definition
+  > = (
+    { inputs },
+  ) => {
+    const { msgContext } = inputs;
+
+    // channel_id sub-property
+    assert<CanBeUndefined<typeof msgContext.channel_id>>(
+      true,
+    );
+    assert<CanBe<typeof msgContext.channel_id, string>>(true);
+    // user_id sub-property
+    assert<CanBeUndefined<typeof msgContext.user_id>>(
+      true,
+    );
+    assert<CanBe<typeof msgContext.user_id, string>>(true);
+    // message_ts sub-property
+    assert<CannotBeUndefined<typeof msgContext.message_ts>>(
+      true,
+    );
+    assert<IsExact<typeof msgContext.message_ts, string>>(true);
     
     return {
       outputs: inputs,


### PR DESCRIPTION
###  Summary

Added `message_ts` to `SlackPrimitiveTypes` and `message_context` to `CustomSlackTypes`. 

Created new `MessageContextType` as the new Custom Type.

Requirements can be found below: 

- `message_ts` should be added to SlackPrimitiveTypes as a simple string
- `message_context` should be added to CustomSlackTypes as a Custom Type definition of an object with properties that can be found here:
https://corp.quip.com/9T6nAE8mUHxn/Reply-In-Thread-Builtin-Function#temp:C:VKKb19fca4ebf8c44c2b9b6732bc

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
