### PR TITLE
Add assertions on definition properties in tests

### DIFF
--- a/src/datastore/datastore_test.ts
+++ b/src/datastore/datastore_test.ts
@@ -30,6 +30,8 @@ Deno.test("Datastore sets appropriate defaults", () => {
       },
     },
   });
+  assertStrictEquals(datastore.definition.name, "dinos");
+  assertStrictEquals(datastore.definition.primary_key, "attr1");
 
   const exported = datastore.export();
   assertStrictEquals(exported.primary_key, "attr1");

--- a/src/events/types_test.ts
+++ b/src/events/types_test.ts
@@ -10,6 +10,7 @@ Deno.test("DefineEvent accepts object types", () => {
     properties: {},
   });
 
+  assertEquals(TestEvent.id, TestEvent.definition.name);
   assertEquals(typeof TestEvent.definition.type, "string");
 });
 

--- a/src/functions/functions_test.ts
+++ b/src/functions/functions_test.ts
@@ -13,6 +13,10 @@ Deno.test("Function sets appropriate defaults", () => {
     source_file: "functions/dino.ts",
   });
 
+  assertEquals(Func.id, Func.definition.callback_id);
+  assertEquals(Func.definition.title, "My function");
+  assertEquals(Func.definition.source_file, "functions/dino.ts");
+
   const exportedFunc = Func.export();
   assertStrictEquals(exportedFunc.source_file, "functions/dino.ts");
   assertEquals(exportedFunc.input_parameters, emptyParameterObject);

--- a/src/workflows/workflows_test.ts
+++ b/src/workflows/workflows_test.ts
@@ -66,6 +66,10 @@ Deno.test("WorkflowStep export input values", () => {
     },
   });
 
+  assertEquals(workflow.id, workflow.definition.callback_id);
+  assertEquals(workflow.definition.title, "test");
+  assertEquals(workflow.definition.description, undefined);
+
   // Add a DefineFunction result as a step
   const step1 = workflow.addStep(TestFunction, {
     email: workflow.inputs.email,


### PR DESCRIPTION
###  Summary

This pull request adds a few assertions, which mainly clarify how id properties are set as the results of Define utility calls, in unit tests. No changes to the main code side.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
