### PR TITLE
Revert "HERMES-4039: mark response_url deprecated"

### DIFF
--- a/src/functions/interactivity/block_actions_types.ts
+++ b/src/functions/interactivity/block_actions_types.ts
@@ -118,9 +118,6 @@ export type BlockActionsBody = {
      */
     user: string;
   };
-  /**
-   * @deprecated Will be removed in a future release. See {@link https://api.slack.com/future/changelog} for more details.
-   */
   response_url: string;
   /**
    * @description The workspace, or team, details the Block Kit interaction originated from.


### PR DESCRIPTION
Reverts slackapi/deno-slack-sdk#115. The team will keep supporting this for now. 