### PR TITLE
Add format property to StringParameterDefinition type

### DIFF
--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -79,6 +79,8 @@ type StringParameterDefinition = BaseParameterDefinition<string> & {
   enum?: string[];
   /** Defines labels that correspond to the `enum` values. */
   choices?: EnumChoice<string>[];
+  /** Define accepted format of the string */
+  format?: "url" | "email";
 };
 
 type IntegerParameterDefinition = BaseParameterDefinition<number> & {


### PR DESCRIPTION
###  Summary

Adds `format` property to StringParameterDefinition type.

## Testing
You can easily clone down this app and follow these [instructions](https://github.com/srajiang/test-format-string/blob/7926cb0d803dc930350d72812b1dde49cb1a485e/functions/greeting_function.ts#L24-L32) to test out the addition. 

Errors you should see: 
1. Manifest validation error when value for `format` does not match either "email" or "url". For example `uri` should both cause a manifest validation error. 
<img width="974" alt="Screenshot 2023-02-01 at 5 14 13 PM" src="https://user-images.githubusercontent.com/55667998/216207926-f4f37c8b-6d28-41ed-a43d-83dbd27e1b1f.png">


2. Parameter validation error when the value does not conform to the specified format
<img width="1066" alt="Screenshot 2023-02-01 at 5 14 46 PM" src="https://user-images.githubusercontent.com/55667998/216207807-42c80b94-c2f4-4232-80a9-b226aa113aa9.png">


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
