### PR TITLE
Fix the link to the Contributing Guidelines in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,5 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 ### Requirements (place an `x` in each `[ ]`)
 
-* [ ] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).


### PR DESCRIPTION
###  Summary

Fix the link in the PR template

#### Testing

1. Try to click the link below to the Contributing Guidelines in this PR
2. Fail

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
