### PR TITLE
Deno editor configuration

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -8,23 +8,34 @@ this project. If you use this package within your own software as is but don't p
 
 All you need to work on this project is a recent version of [Deno](https://deno.land/)
 
+<details>
+  <summary>Note</summary>
+
+* You can set up shell completion by flowing the [Shell Completion](https://deno.land/manual/getting_started/setup_your_environment#shell-completions) guidelines.
+
+</details>
+
 ## Tasks
 
 ### Testing
 
 Test can be run directly with Deno:
 
-    deno task test
+  ```zsh
+  deno task test
+  ```
 
 You can also run a test coverage report with:
 
-    deno task coverage
+  ```zsh
+  deno task coverage
+  ```
 
 Sometimes you may need to test out changes in this SDK in a sample app or project. In order to do this, commit your intended history to a remote branch and note the full commit SHA. `(e.g. fc0a0a1f0722e28fecb7782513d045522d7c0d6f)`
 
-Then in your sample app's `import_map.json` file, replace the `deno-slack-sdk` import url with: 
+Then in your sample app's `import_map.json` file, replace the `deno-slack-sdk` import url with:
 
-```
+```json
 {
   "imports": {
     "deno-slack-sdk/": "https://raw.githubusercontent.com/slackapi/deno-slack-sdk/<commit-SHA-goes-here>/src/",
@@ -35,6 +46,23 @@ Then in your sample app's `import_map.json` file, replace the `deno-slack-sdk` i
 
 You may need to reload your modules if they've been cached: https://deno.land/manual@v1.29.1/basics/modules/reloading_modules
 
+### Lint and format
+
+The linting and formatting rules are defined in the `deno.jsonc` file, your IDE can be set up to follow these rules:
+
+1. Refer to the [Deno Set Up Your Environment](https://deno.land/manual/getting_started/setup_your_environment) guidelines to set up your IDE with the proper plugin.
+2. Ensure that the `deno.jsonc` file is set as the configuration file for your IDE plugin
+   * If you are using VS code [this](https://deno.land/manual/references/vscode_deno#using-a-configuration-file) is already configured in `.vscode/settings.json`
+
+#### Linting
+
+The list of linting rules can be found in [the linting deno docs](https://lint.deno.land/).
+Currently we apply all recommended rules.
+
+#### Format
+
+The list of format options is defined in the `deno.jsonc` file. They closely resemble the default values.
+
 ### Releasing
 
 Releases for this library are automatically generated off of git tags. Before creating a new release, ensure that everything on the `main` branch since the last tag is in a releasable state! At a minimum, [run the tests](#testing).
@@ -43,15 +71,17 @@ To create a new release:
 
 1. Create a new GitHub Release from the [Releases page](https://github.com/slackapi/deno-slack-sdk/releases) by clicking the "Draft a new release" button.
 2. Input a new version manually into the "Choose a tag" input. You can start off by incrementing the version to reflect a patch. (i.e. 1.16.0 -> 1.16.1)
-    - After you input the new version, click the "Create a new tag: x.x.x on publish" button. This won't create your tag immediately.
-    - Auto-generate the release notes by clicking the "Auto-generate release notes" button. This will pull in changes that will be included in your release. 
-    - Flip to the preview mode and review the pull request labels of the changes included in this release (i.e. `semver:minor` `semver:patch`, `semver:major`). Tip: Your release version should be based on the tag of the largest change, so if this release includes a `semver:minor`, the release version in your tag should be upgraded to reflect a minor. 
-    - Ensure that this version adheres to [semantic versioning][semver]. See [Versioning](#versioning) for correct version format. Version tags should match the following pattern: `1.0.1` (no `v` preceding the number).
+
+     * After you input the new version, click the "Create a new tag: x.x.x on publish" button. This won't create your tag immediately.
+     * Auto-generate the release notes by clicking the "Auto-generate release notes" button. This will pull in changes that will be included in your release.
+     * Flip to the preview mode and review the pull request labels of the changes included in this release (i.e. `semver:minor` `semver:patch`, `semver:major`). Tip: Your release version should be based on the tag of the largest change, so if this release includes a `semver:minor`, the release version in your tag should be upgraded to reflect a minor.
+     * Ensure that this version adheres to [semantic versioning][semver]. See [Versioning](#versioning-and-tags) for correct version format. Version tags should match the following pattern: `1.0.1` (no `v` preceding the number).
+
 3. Set the "Target" input to the "main" branch.
 4. Name the release title after the version tag.
 5. Make any adjustments to generated release notes to make sure they are accessible and approachable and that an end-user with little context about this project could still understand.
-7. Publish the release by clicking the "Publish release" button!
-8. After a few minutes, the corresponding version will be available on https://deno.land/x/deno_slack_sdk.
+6. Publish the release by clicking the "Publish release" button!
+7. After a few minutes, the corresponding version will be available on https://deno.land/x/deno_slack_sdk.
 
 ## Workflow
 

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -11,7 +11,7 @@ All you need to work on this project is a recent version of [Deno](https://deno.
 <details>
   <summary>Note</summary>
 
-* You can set up shell completion by fallowing the [Shell Completion](https://deno.land/manual/getting_started/setup_your_environment#shell-completions) guidelines.
+* You can set up shell completion by following the [Shell Completion](https://deno.land/manual/getting_started/setup_your_environment#shell-completions) guidelines.
 
 </details>
 

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -11,7 +11,7 @@ All you need to work on this project is a recent version of [Deno](https://deno.
 <details>
   <summary>Note</summary>
 
-* You can set up shell completion by flowing the [Shell Completion](https://deno.land/manual/getting_started/setup_your_environment#shell-completions) guidelines.
+* You can set up shell completion by fallowing the [Shell Completion](https://deno.land/manual/getting_started/setup_your_environment#shell-completions) guidelines.
 
 </details>
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
   "deno.enable": true,
   "deno.lint": true,
+  "deno.config": "./deno.jsonc",
   "[typescript]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "denoland.vscode-deno"
-  },
-  "editor.tabSize": 2
+  }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,8 +1,17 @@
 {
+  "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "fmt": {
     "files": {
       "include": ["src", "tests"],
       "exclude": ["src/schema/slack/functions/_scripts/functions.json", "**/*.md"]
+    },
+    "options": {
+      "semiColons": true,
+      "indentWidth": 2,
+      "lineWidth": 80,
+      "proseWrap": "always",
+      "singleQuote": false,
+      "useTabs": false
     }
   },
   "lint": {
@@ -11,11 +20,15 @@
       "exclude": ["src/schema/slack/functions/_scripts/functions.json", "**/*.md"]
     }
   },
+  "test": {
+    "files": {
+      "include": ["src", "tests"]
+    }
+  },
   "tasks": {
-    // TODO: the bundle command should be `deno bundle src/mod.ts > /dev/null` (less noisy), but redirects are not currently supported in task commands
-    "test": "deno fmt --check && deno lint && deno bundle src/mod.ts && deno test src tests",
-    "coverage": "deno test --coverage=.coverage src tests && deno coverage --exclude=fixtures --exclude=test .coverage",
-    "coverage-lcov": "deno test --coverage=.coverage src tests && deno coverage --exclude=fixtures --exclude=test .coverage --lcov --output=lcov.info"
+    "test": "deno fmt --check && deno lint && deno bundle src/mod.ts && deno test",
+    "coverage": "deno test --coverage=.coverage && deno coverage --exclude=fixtures --exclude=test .coverage",
+    "coverage-lcov": "deno test --coverage=.coverage && deno coverage --exclude=fixtures --exclude=test .coverage --lcov --output=lcov.info"
   },
   "lock": false
 }


### PR DESCRIPTION
###  Summary

Original request suggests moving to `.editorconfig` to set formatting and linting rules. After doing some research on [Deno development environments](https://deno.land/manual/getting_started/setup_your_environment), I created this PR in which all the formatting and linting rules are defined in the `deno.jsonc` file. 

Deno supports multiple IDE's with plugins that allow to set the `deno.json` file as the configuration file for formatting and linting. I've updated the vscode `settings.json` file to use this configuration file.

Users of other IDEs will be able to follow the steps in the `maintainers_guide` to set up their IDE with the proper plugin and reference the `deno.jsonc` file.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
