### PR TITLE
Integrate a better CLI utility for generating code coverage reports.

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -27,8 +27,7 @@
   },
   "tasks": {
     "test": "deno fmt --check && deno lint && deno bundle src/mod.ts && deno test --allow-read",
-    "coverage": "deno test --allow-read --coverage=.coverage && deno coverage --exclude=fixtures --exclude=test .coverage",
-    "coverage-lcov": "deno test --allow-read --coverage=.coverage && deno coverage --exclude=fixtures --exclude=test .coverage --lcov --output=lcov.info"
+    "coverage": "deno test --allow-read --coverage=.coverage && deno coverage --exclude=fixtures --exclude=test --lcov --output=lcov.info .coverage && deno run --allow-read https://deno.land/x/code_coverage@0.2.0/cli.ts"
   },
   "lock": false
 }


### PR DESCRIPTION
###  Summary

Small tweak to the coverage task, I think the output is much nicer and it also gives you a project-wide total (which the built-in deno CLI `deno coverage` tool does not):

<img width="1427" alt="Screenshot 2023-03-01 at 12 45 50 PM" src="https://user-images.githubusercontent.com/52645/222223859-b2e46151-570b-4be5-a4bb-13d41b85f30a.png">
