### PR TITLE
Dont use Parameters as a generic name because it's a utility

### DIFF
--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -55,16 +55,14 @@ export type WorkflowStepOutputs<
 > = WorkflowParameterReferences<Params, RequiredParams>;
 
 type WorkflowParameterReferences<
-  Parameters extends ParameterSetDefinition,
-  Required extends PossibleParameterKeys<Parameters>,
+  Params extends ParameterSetDefinition,
+  Required extends PossibleParameterKeys<Params>,
 > =
   & {
-    [name in Required[number]]: ParameterVariableType<
-      Parameters[name]
-    >;
+    [name in Required[number]]: ParameterVariableType<Params[name]>;
   }
   & {
-    [name in keyof Parameters]?: ParameterVariableType<Parameters[name]>;
+    [name in keyof Params]?: ParameterVariableType<Params[name]>;
   };
 
 // Workflow Step inputs are different than workflow inputs/outputs or workflow step outputs.


### PR DESCRIPTION
###  Summary

Found this instance where we're naming a generic variable `Parameters` which is a utility type.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
