### PR TITLE
Add versioning details and contract callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check out the [`./docs`](./docs) directory!
 
 ## Versioning
 
-Releases for this repository follows the [SemVer](https://semver.org/) versioning scheme. Breaking changes are determined by the top-level `src/mod.ts` and `src/types.ts` files. Exports not included in these files are deemed internal. As such they should be treated as unstable features and used at your own risk.
+Releases for this repository follows the [SemVer](https://semver.org/) versioning scheme. The SDK's contract is determined by the top-level exports from the `src/mod.ts` and `src/types.ts` files. Exports not included in these files are deemed internal and any modifications will not be treated as breaking changes. As such, internal exports should be treated as unstable and used at your own risk.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A recent version of `deno`.
 
 Check out the [`./docs`](./docs) directory!
 
+## Versioning
+
+Releases for this repository follows the [SemVer](https://semver.org/) versioning scheme. Breaking changes are determined by the top-level `src/mod.ts` and `src/types.ts` files. Exports not included in these files are deemed internal. As such they should be treated as unstable features and used at your own risk.
+
 ## Running Tests
 
 If you make changes to this repo, or just want to make sure things are working as desired, you can run:


### PR DESCRIPTION
###  Summary

We want to make it clear to developers that the contract we follow for SemVer is for the `src/mod.ts` and `src/types.ts` files only. Any use of exports from internal files are considered unstable.

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
