### PR TITLE
Add test around oauth2 parameters

### DIFF
--- a/src/functions/definefunction_test.ts
+++ b/src/functions/definefunction_test.ts
@@ -143,3 +143,35 @@ Deno.test("DefineFunction with output parameters but no input parameters", () =>
     NoInputParamFunction.definition.output_parameters,
   );
 });
+
+Deno.test("DefineFunction using an OAuth2 property requests a provider key", () => {
+  /**
+   * The `oauth2_provider_key` is not currently required because `type` supports any string
+   * But eventually we'd like to support static errors for OAuth2 properties without the provider key
+   */
+
+  const OAuth2Function = DefineFunction({
+    callback_id: "output_params_only",
+    title: "No Parameter Function",
+    source_file: "functions/output_params_only.ts",
+    input_parameters: {
+      properties: {
+        googleAccessTokenId: {
+          type: Schema.slack.types.oauth2,
+          oauth2_provider_key: "test",
+        },
+      },
+      required: [],
+    },
+  });
+
+  assertEquals(
+    {
+      googleAccessTokenId: {
+        oauth2_provider_key: "test",
+        type: Schema.slack.types.oauth2,
+      },
+    },
+    OAuth2Function.export().input_parameters.properties,
+  );
+});


### PR DESCRIPTION
###  Summary

This PR adds a test for OAuth2 parameters. This test in isolation doesn't do much for us, but it documents a test case that we ideally want to support when we support custom parameter definitions for custom Slack types.

The idea here is that as part of implementing custom parameter definitions for custom Slack types and making OAuth2 the first instance, we'd find and update this test accordingly.

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
