### PR TITLE
Add 'require_end_user_auth' property

### DIFF
--- a/src/functions/definefunction_test.ts
+++ b/src/functions/definefunction_test.ts
@@ -193,3 +193,32 @@ Deno.test("DefineFunction using an OAuth2 property requests a provider key", () 
     OAuth2Function.export().input_parameters.properties,
   );
 });
+
+Deno.test("DefineFunction using an OAuth2 property allows require_end_user_auth", () => {
+  const OAuth2Function = DefineFunction({
+    callback_id: "oauth",
+    title: "OAuth Function",
+    source_file: "functions/oauth.ts",
+    input_parameters: {
+      properties: {
+        googleAccessTokenId: {
+          type: Schema.slack.types.oauth2,
+          oauth2_provider_key: "test",
+          require_end_user_auth: true,
+        },
+      },
+      required: [],
+    },
+  });
+
+  assertEquals(
+    {
+      googleAccessTokenId: {
+        oauth2_provider_key: "test",
+        type: Schema.slack.types.oauth2,
+        require_end_user_auth: true,
+      },
+    },
+    OAuth2Function.export().input_parameters.properties,
+  );
+});

--- a/src/parameters/definition_types.ts
+++ b/src/parameters/definition_types.ts
@@ -145,6 +145,7 @@ interface NumberParameterDefinition extends BaseParameterDefinition<number> {
 interface OAuth2ParameterDefinition extends BaseParameterDefinition<string> {
   type: typeof SlackPrimitiveTypes.oauth2;
   oauth2_provider_key: string;
+  require_end_user_auth: boolean;
 }
 
 type EnumChoice<T> = {


### PR DESCRIPTION
###  Summary
Developers of some functions may want to enforce end user auth for policy reasons. Examples include Zoom where only end user's auth should be used to start a Zoom meeting, or Salesforce where only the end user's auth is used to update a Salesforce opportunity. 

In this PR, we're adding a new property called `require_end_user_auth` for the `oauth2` input type. When this property is set, the Builder UI disable the auth delegation toggle and default to end user auth.

More context on requirements and naming in [this](https://slack-pde.slack.com/archives/C02TBKP7CAZ/p1682115306454349) thread.

[Here](https://slack-github.com/slack/webapp/pull/184865) is the webapp PR to start accepting this property.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
