### PR TITLE
Bump the deno-slack-api version

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,5 @@
-export { SlackAPI } from "https://deno.land/x/deno_slack_api@2.1.0/mod.ts";
+export { SlackAPI } from "https://deno.land/x/deno_slack_api@2.1.1/mod.ts";
 export type {
   SlackAPIClient,
   Trigger,
-} from "https://deno.land/x/deno_slack_api@2.1.0/types.ts";
+} from "https://deno.land/x/deno_slack_api@2.1.1/types.ts";


### PR DESCRIPTION
###  Summary

This PR simply bumps the deno-slack-api version to the latest

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
