### PR TITLE
Provide typeahead for the `type` property

### DIFF
--- a/src/datastore/types.ts
+++ b/src/datastore/types.ts
@@ -1,10 +1,15 @@
 import { ICustomType } from "../types/types.ts";
 import { ManifestDatastoreSchema } from "../manifest/manifest_schema.ts";
 import { SlackManifest } from "../manifest/mod.ts";
+import type { ValidSchemaTypes } from "../schema/schema_types.ts";
+import type { ValidSlackPrimitiveTypes } from "../schema/slack/types/mod.ts";
+import type { LooseStringAutocomplete } from "../type_utils.ts";
 
 export type SlackDatastoreAttribute = {
   // supports custom types, primitive types, inline objects and lists
-  type: string | ICustomType;
+  type:
+    | LooseStringAutocomplete<ValidSchemaTypes | ValidSlackPrimitiveTypes>
+    | ICustomType;
 };
 
 export type SlackDatastoreAttributes = Record<string, SlackDatastoreAttribute>;

--- a/src/datastore/types.ts
+++ b/src/datastore/types.ts
@@ -8,7 +8,6 @@ import type { LooseStringAutocomplete } from "../type_utils.ts";
 
 type InvalidDatastoreTypes =
   | typeof SlackPrimitiveTypes.blocks
-  | typeof SlackPrimitiveTypes.message_ts
   | typeof SlackPrimitiveTypes.oauth2;
 
 type ValidDatastoreTypes = Exclude<

--- a/src/datastore/types.ts
+++ b/src/datastore/types.ts
@@ -1,15 +1,25 @@
 import { ICustomType } from "../types/types.ts";
 import { ManifestDatastoreSchema } from "../manifest/manifest_schema.ts";
 import { SlackManifest } from "../manifest/mod.ts";
+import { SlackPrimitiveTypes } from "../schema/slack/types/mod.ts";
 import type { ValidSchemaTypes } from "../schema/schema_types.ts";
 import type { ValidSlackPrimitiveTypes } from "../schema/slack/types/mod.ts";
 import type { LooseStringAutocomplete } from "../type_utils.ts";
 
+type InvalidDatastoreTypes =
+  | typeof SlackPrimitiveTypes.blocks
+  | typeof SlackPrimitiveTypes.message_ts
+  | typeof SlackPrimitiveTypes.oauth2;
+
+type ValidDatastoreTypes = Exclude<
+  | ValidSchemaTypes
+  | ValidSlackPrimitiveTypes,
+  InvalidDatastoreTypes
+>;
+
 export type SlackDatastoreAttribute = {
   // supports custom types, primitive types, inline objects and lists
-  type:
-    | LooseStringAutocomplete<ValidSchemaTypes | ValidSlackPrimitiveTypes>
-    | ICustomType;
+  type: LooseStringAutocomplete<ValidDatastoreTypes> | ICustomType;
 };
 
 export type SlackDatastoreAttributes = Record<string, SlackDatastoreAttribute>;

--- a/src/parameters/definition_types.ts
+++ b/src/parameters/definition_types.ts
@@ -1,5 +1,9 @@
-import SchemaTypes from "../schema/schema_types.ts";
-import { SlackPrimitiveTypes } from "../schema/slack/types/mod.ts";
+import SchemaTypes, { ValidSchemaTypes } from "../schema/schema_types.ts";
+import {
+  SlackPrimitiveTypes,
+  ValidSlackPrimitiveTypes,
+} from "../schema/slack/types/mod.ts";
+import { LooseStringAutocomplete } from "../type_utils.ts";
 import { ICustomType } from "../types/types.ts";
 
 export type ParameterDefinition = TypedParameterDefinition;
@@ -25,15 +29,9 @@ export interface CustomTypeParameterDefinition
   type: ICustomType;
 }
 
-type TypeUnion =
-  | typeof SchemaTypes[keyof typeof SchemaTypes]
-  | typeof SlackPrimitiveTypes[keyof typeof SlackPrimitiveTypes]
-  // deno-lint-ignore ban-types
-  | (string & {});
-
 interface BaseParameterDefinition<T> {
   /** Defines the parameter type. */
-  type: TypeUnion;
+  type: LooseStringAutocomplete<ValidSchemaTypes | ValidSlackPrimitiveTypes>;
   /** An optional parameter title. */
   title?: string;
   /** An optional parameter description. */

--- a/src/parameters/definition_types.ts
+++ b/src/parameters/definition_types.ts
@@ -25,9 +25,15 @@ export interface CustomTypeParameterDefinition
   type: ICustomType;
 }
 
+type TypeUnion =
+  | typeof SchemaTypes[keyof typeof SchemaTypes]
+  | typeof SlackPrimitiveTypes[keyof typeof SlackPrimitiveTypes]
+  // deno-lint-ignore ban-types
+  | (string & {});
+
 interface BaseParameterDefinition<T> {
   /** Defines the parameter type. */
-  type: string;
+  type: TypeUnion;
   /** An optional parameter title. */
   title?: string;
   /** An optional parameter description. */

--- a/src/schema/schema_types.ts
+++ b/src/schema/schema_types.ts
@@ -7,4 +7,6 @@ const SchemaTypes = {
   array: "array",
 } as const;
 
+export type ValidSchemaTypes = typeof SchemaTypes[keyof typeof SchemaTypes];
+
 export default SchemaTypes;

--- a/src/schema/slack/types/mod.ts
+++ b/src/schema/slack/types/mod.ts
@@ -10,4 +10,7 @@ const SlackPrimitiveTypes = {
   message_ts: "slack#/types/message_ts",
 } as const;
 
+export type ValidSlackPrimitiveTypes =
+  typeof SlackPrimitiveTypes[keyof typeof SlackPrimitiveTypes];
+
 export { SlackPrimitiveTypes };

--- a/src/type_utils.ts
+++ b/src/type_utils.ts
@@ -13,3 +13,7 @@ export type IncreaseDepth<Depth extends RecursionDepthLevel = 0> = Depth extends
   : Depth extends 4 ? 5
   : Depth extends 5 ? MaxRecursionDepth
   : MaxRecursionDepth;
+
+/** @description Provides typeahead for passed strict string values while allowing any other string to be passed as well */
+// deno-lint-ignore ban-types
+export type LooseStringAutocomplete<T> = T | (string & {});


### PR DESCRIPTION
###  Summary

Show users via typeahead what values are accepted in the `type` field for functions and datastores while still allowing any other string value to be passed

[h/t to Matt Pocock](https://twitter.com/mattpocockuk/status/1671908303918473217?cxt=HHwWgoCxgdHv57MuAAAA)

### Demo
https://github.com/slackapi/deno-slack-sdk/assets/20157895/043cd7e3-234d-4fa3-aa4b-8b89c3e8803b

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
