### PR TITLE
[HERMES-5354] Add `userScopes` to `ISlackManifestShared`

### DIFF
--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -745,6 +745,32 @@ Deno.test("Manifest() correctly assigns other app features", () => {
   );
 });
 
+Deno.test("Manifest() ensures that apps defining user-level scopes also manage tokens", () => {
+  const definition: SlackManifestType = {
+    runOnSlack: false,
+    name: "fear and loathing in las vegas",
+    description:
+      "fear and loathing in las vegas: a savage journey to the heart of the american dream",
+    displayName: "fear and loathing",
+    icon: "icon.png",
+    botScopes: ["channels:history", "chat:write", "commands"],
+    userScopes: ["users:read"],
+  };
+  const manifest = Manifest(definition);
+
+  // ensure user scopes are set on the manifest
+  assertStrictEquals(
+    manifest.oauth_config.scopes.user,
+    definition.userScopes,
+  );
+
+  // ensure that token management is set to true
+  assertStrictEquals(
+    manifest.oauth_config.token_management_enabled,
+    true,
+  );
+});
+
 Deno.test("SlackManifest() registration functions don't allow duplicates", () => {
   const functionId = "test_function";
   const arrayTypeId = "test_array_type";

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -50,6 +50,7 @@ export class SlackManifest {
       oauth_config: {
         scopes: {
           bot: this.ensureBotScopes(),
+          user: def.userScopes,
         },
       },
       features: {
@@ -256,10 +257,9 @@ export class SlackManifest {
     manifest.app_directory = def.appDirectory;
 
     //OauthConfig
-    manifest.oauth_config.scopes.user = def.userScopes;
     manifest.oauth_config.redirect_urls = def.redirectUrls;
 
-    // Remote-hosted Slack apps manage their own tokens
+    // Remote-hosted Slack apps always manage their own tokens
     manifest.oauth_config.token_management_enabled = true;
 
     // Remote Features
@@ -274,9 +274,11 @@ export class SlackManifest {
   private assignRunOnSlackManifestProperties(manifest: ManifestSchema) {
     const def = this.definition as ISlackManifestRunOnSlack;
 
-    // Run on Slack Apps do not manage access tokens
-    // This is set by default as false
-    manifest.oauth_config.token_management_enabled = false;
+    // Oauth Config
+    // Run On Slack manage their own tokens
+    // if and only if user scopes are included in the manifest
+    manifest.oauth_config.token_management_enabled =
+      manifest.oauth_config.scopes.user != undefined;
 
     // Required App Settings for run on slack apps
     manifest.settings.org_deploy_enabled = true;

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -60,26 +60,26 @@ export interface ISlackManifestRemote extends ISlackManifestShared {
   socketModeEnabled?: boolean;
   tokenRotationEnabled?: boolean;
   appDirectory?: ManifestAppDirectorySchema;
-  userScopes?: Array<string>;
   redirectUrls?: Array<string>;
   features?: ISlackManifestRemoteFeaturesSchema;
 }
 
 /* Shared app manifest properties */
 interface ISlackManifestShared {
-  name: string;
   backgroundColor?: string;
+  botScopes: Array<string>;
+  datastores?: ManifestDatastore[];
   description: string;
   displayName?: string;
+  events?: ICustomEvent[];
+  functions?: ManifestFunction[];
   icon: string;
   longDescription?: string;
-  botScopes: Array<string>;
-  functions?: ManifestFunction[];
-  workflows?: ManifestWorkflow[];
+  name: string;
   outgoingDomains?: Array<string>;
-  events?: ICustomEvent[];
   types?: ICustomType[];
-  datastores?: ManifestDatastore[];
+  userScopes?: Array<string>;
+  workflows?: ManifestWorkflow[];
 }
 
 interface ISlackManifestRunOnSlackFeaturesSchema {


### PR DESCRIPTION
###  Summary
Adds the `userScopes` property to the ISlackManifestShared interface.
Ask from Hermes User Delegated Auth folks to enable authoring app manifest that use built-ins with user-delegated auth. 

[Context thread](https://slack-pde.slack.com/archives/C0478C43T4J/p1687192300541109)

Changes: 
* Moves `userScopes` property to the `ISlackManifestShared` interface
* Sets the value
* Normally Run on Slack apps have `token_management_enabled` defaulted to false on behalf of the developer. But in the case where user scopes are requested, the backend requires `token_management_enabled` to be set to `true`. So I have modified the SDK behavior to default to setting the value to true only when user scopes are defined. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
