### PR TITLE
Consolidate oauth2 provider type

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -19,6 +19,7 @@ jobs:
           - slack-samples/deno-message-translator
           - slack-samples/deno-request-time-off
           - slack-samples/deno-simple-survey
+          - slack-samples/deno-github-functions
 
     steps:
       - name: Setup Deno

--- a/src/manifest/manifest_schema.ts
+++ b/src/manifest/manifest_schema.ts
@@ -5,6 +5,7 @@ import type { ParameterDefinition } from "../parameters/definition_types.ts";
 import { OAuth2ProviderTypeValues } from "../schema/providers/oauth2/types.ts";
 import type { ICustomType } from "../types/types.ts";
 import { ISlackWorkflow } from "../workflows/types.ts";
+import { OAuth2ProviderOptions } from "../providers/oauth2/types.ts";
 
 // ----------------------------------------------------------------------------
 // Manifest Schema Types
@@ -295,35 +296,8 @@ export type ManifestOAuth2Schema = {
 };
 
 export type ManifestOAuth2ProviderSchema = {
-  /** Type of the provider */
   provider_type: OAuth2ProviderTypeValues;
-  /** OAuth2 Configuration options for the provider */
-  options: OAuth2ProviderOptionsSchema;
-};
-
-export type OAuth2ProviderOptionsSchema = {
-  /** Client id for the provider */
-  client_id: string;
-  /** Scopes for the provider */
-  scope: string[];
-  /** Display name for the provider. Required for CUSTOM provider types. */
-  provider_name?: string;
-  /** Authorization url for the provider. Required for CUSTOM provider types. */
-  authorization_url?: string;
-  /** Token url for the provider. Required for CUSTOM provider types. */
-  token_url?: string;
-  /** Identity configuration for the provider. Required for CUSTOM provider types. */
-  identity_config?: OAuth2ProviderIdentitySchema;
-  /** Optional extras dict for authorization url for your provider. Required for CUSTOM provider types. */
-  authorization_url_extras?: { [key: string]: string };
-};
-
-export type OAuth2ProviderIdentitySchema = {
-  url: string;
-  account_identifier: string;
-  headers?: {
-    [key: string]: string;
-  };
+  options: OAuth2ProviderOptions;
 };
 
 export interface ManifestExternalAuthProviders {

--- a/src/manifest/manifest_schema.ts
+++ b/src/manifest/manifest_schema.ts
@@ -295,10 +295,34 @@ export type ManifestOAuth2Schema = {
 };
 
 export type ManifestOAuth2ProviderSchema = {
+  /** Type of the provider */
   provider_type: OAuth2ProviderTypeValues;
-  options: {
-    // deno-lint-ignore no-explicit-any
-    [key: string]: any;
+  /** OAuth2 Configuration options for the provider */
+  options: OAuth2ProviderOptionsSchema;
+};
+
+export type OAuth2ProviderOptionsSchema = {
+  /** Client id for the provider */
+  client_id: string;
+  /** Scopes for the provider */
+  scope: string[];
+  /** Display name for the provider. Required for CUSTOM provider types. */
+  provider_name?: string;
+  /** Authorization url for the provider. Required for CUSTOM provider types. */
+  authorization_url?: string;
+  /** Token url for the provider. Required for CUSTOM provider types. */
+  token_url?: string;
+  /** Identity configuration for the provider. Required for CUSTOM provider types. */
+  identity_config?: OAuth2ProviderIdentitySchema;
+  /** Optional extras dict for authorization url for your provider. Required for CUSTOM provider types. */
+  authorization_url_extras?: { [key: string]: string };
+};
+
+export type OAuth2ProviderIdentitySchema = {
+  url: string;
+  account_identifier: string;
+  headers?: {
+    [key: string]: string;
   };
 };
 

--- a/src/providers/oauth2/mod.ts
+++ b/src/providers/oauth2/mod.ts
@@ -1,10 +1,9 @@
-import {
-  OAuth2ProviderDefinitionArgs,
-  OAuth2ProviderOptions,
-} from "./types.ts";
-
+import { OAuth2ProviderDefinitionArgs } from "./types.ts";
 import { OAuth2ProviderTypeValues } from "../../schema/providers/oauth2/types.ts";
-import { ManifestOAuth2ProviderSchema } from "../../manifest/manifest_schema.ts";
+import {
+  ManifestOAuth2ProviderSchema,
+  OAuth2ProviderOptionsSchema,
+} from "../../manifest/manifest_schema.ts";
 
 export const DefineOAuth2Provider = (
   definition: OAuth2ProviderDefinitionArgs,
@@ -15,7 +14,7 @@ export const DefineOAuth2Provider = (
 export class OAuth2Provider {
   public id: string;
   private provider_type: OAuth2ProviderTypeValues;
-  private options: OAuth2ProviderOptions;
+  private options: OAuth2ProviderOptionsSchema;
 
   constructor(
     public definition: OAuth2ProviderDefinitionArgs,

--- a/src/providers/oauth2/mod.ts
+++ b/src/providers/oauth2/mod.ts
@@ -1,8 +1,10 @@
-import { OAuth2ProviderDefinitionArgs } from "./types.ts";
+import {
+  OAuth2ProviderDefinitionArgs,
+  OAuth2ProviderOptions,
+} from "./types.ts";
 import { OAuth2ProviderTypeValues } from "../../schema/providers/oauth2/types.ts";
 import {
   ManifestOAuth2ProviderSchema,
-  OAuth2ProviderOptionsSchema,
 } from "../../manifest/manifest_schema.ts";
 
 export const DefineOAuth2Provider = (
@@ -14,7 +16,7 @@ export const DefineOAuth2Provider = (
 export class OAuth2Provider {
   public id: string;
   private provider_type: OAuth2ProviderTypeValues;
-  private options: OAuth2ProviderOptionsSchema;
+  private options: OAuth2ProviderOptions;
 
   constructor(
     public definition: OAuth2ProviderDefinitionArgs,

--- a/src/providers/oauth2/types.ts
+++ b/src/providers/oauth2/types.ts
@@ -4,3 +4,33 @@ export type OAuth2ProviderDefinitionArgs = ManifestOAuth2ProviderSchema & {
   /** A unique name for the provider */
   provider_key: string;
 };
+
+/**
+ * TODO: The type system here could be improved one more then one provider type (CUSTOM) is available
+ * provider_name, authorization_url, token_url, identity_config and authorization_url_extras
+ * are only required for CUSTOM provider types
+ */
+export type OAuth2ProviderOptions = {
+  /** Client id for the provider */
+  client_id: string;
+  /** Scopes for the provider */
+  scope: string[];
+  /** Display name for the provider. Required for CUSTOM provider types. */
+  provider_name?: string;
+  /** Authorization url for the provider. Required for CUSTOM provider types. */
+  authorization_url?: string;
+  /** Token url for the provider. Required for CUSTOM provider types. */
+  token_url?: string;
+  /** Identity configuration for the provider. Required for CUSTOM provider types. */
+  identity_config?: OAuth2ProviderIdentity;
+  /** Optional extras dict for authorization url for your provider. Required for CUSTOM provider types. */
+  authorization_url_extras?: { [key: string]: string };
+};
+
+export type OAuth2ProviderIdentity = {
+  url: string;
+  account_identifier: string;
+  headers?: {
+    [key: string]: string;
+  };
+};

--- a/src/providers/oauth2/types.ts
+++ b/src/providers/oauth2/types.ts
@@ -1,35 +1,6 @@
-import { OAuth2ProviderTypeValues } from "../../schema/providers/oauth2/types.ts";
+import { ManifestOAuth2ProviderSchema } from "../../manifest/manifest_schema.ts";
 
-export type OAuth2ProviderIdentitySchema = {
-  "url": string;
-  "account_identifier": string;
-  "headers"?: {
-    [key: string]: string;
-  };
-};
-
-export type OAuth2ProviderOptions = {
-  /** Client id for your provider */
-  "client_id": string;
-  /** Scopes for your provider */
-  "scope": string[];
-  /** Display name for your provider. Required for CUSTOM provider types. */
-  "provider_name"?: string;
-  /** Authorization url for your provider. Required for CUSTOM provider types. */
-  "authorization_url"?: string;
-  /** Token url for your provider. Required for CUSTOM provider types. */
-  "token_url"?: string;
-  /** Identity configuration for your provider. Required for CUSTOM provider types. */
-  "identity_config"?: OAuth2ProviderIdentitySchema;
-  /** Optional extras dict for authorization url for your provider. Required for CUSTOM provider types. */
-  "authorization_url_extras"?: { [key: string]: string };
-};
-
-export type OAuth2ProviderDefinitionArgs = {
-  /** A unique name for your provider */
+export type OAuth2ProviderDefinitionArgs = ManifestOAuth2ProviderSchema & {
+  /** A unique name for the provider */
   provider_key: string;
-  /** Type of your provider */
-  provider_type: OAuth2ProviderTypeValues;
-  /** OAuth2 Configuration options for your provider */
-  options: OAuth2ProviderOptions;
 };


### PR DESCRIPTION
###  Summary

This PR aims to address [this comment](https://github.com/slackapi/deno-slack-sdk/pull/192#discussion_r1276486102) that asks to consolidate `ManifestOAuth2ProviderSchema` and `OAuth2ProviderDefinitionArgs`

I've left a TODO comment that mentiones that some work regarding the `type` system could be done once more then one Provider types are present.

#### testing
1. Open an app with an OAuth2 provider such as [deno-simple-survey](https://github.com/slack-samples/deno-simple-survey)
2. replace the `"deno-slack-sdk/"` value with `"https://raw.githubusercontent.com/slackapi/deno-slack-sdk/consolidate-Oauth2ProviderType/src/"`
3. Run the app
4. Everything should work as expected

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
