### PR TITLE
adding use basic auth scheme config

### DIFF
--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -1348,12 +1348,8 @@ Deno.test("Manifest throws error when Providers with duplicate provider_keys are
 });
 
 Deno.test("SlackManifest() oauth2 providers get set properly with token_url_config", () => {
+  // test with token_url_config unset
   const providerKey1 = "test_provider_with_token_url_config_unset";
-  const providerKey2 =
-    "test_provider_with_use_basic_authentication_scheme_false";
-  const providerKey3 =
-    "test_provider_with_use_basic_authentication_scheme_true";
-
   const Provider1 = DefineOAuth2Provider({
     provider_key: providerKey1,
     provider_type: Schema.providers.oauth2.CUSTOM,
@@ -1363,7 +1359,9 @@ Deno.test("SlackManifest() oauth2 providers get set properly with token_url_conf
       "token_url_config": {},
     },
   });
-
+  // test with use_basic_authentication_scheme false
+  const providerKey2 =
+    "test_provider_with_use_basic_authentication_scheme_false";
   const Provider2 = DefineOAuth2Provider({
     provider_key: providerKey2,
     provider_type: Schema.providers.oauth2.CUSTOM,
@@ -1375,7 +1373,9 @@ Deno.test("SlackManifest() oauth2 providers get set properly with token_url_conf
       },
     },
   });
-
+  // test with use_basic_authentication_scheme true
+  const providerKey3 =
+    "test_provider_with_use_basic_authentication_scheme_true";
   const Provider3 = DefineOAuth2Provider({
     provider_key: providerKey3,
     provider_type: Schema.providers.oauth2.CUSTOM,
@@ -1387,7 +1387,6 @@ Deno.test("SlackManifest() oauth2 providers get set properly with token_url_conf
       },
     },
   });
-
   const definition: SlackManifestType = {
     name: "Name",
     description: "Description",
@@ -1412,18 +1411,21 @@ Deno.test("SlackManifest() oauth2 providers get set properly with token_url_conf
         .export(),
     },
   });
+  // test with use_basic_authentication_scheme unset
   assertStrictEquals(
     exportedManifest.external_auth_providers?.oauth2
       ?.test_provider_with_token_url_config_unset?.options
       ?.token_url_config?.use_basic_authentication_scheme,
     undefined,
   );
+  // test with use_basic_authentication_scheme false
   assertStrictEquals(
     exportedManifest.external_auth_providers?.oauth2
       ?.test_provider_with_use_basic_authentication_scheme_false?.options
       ?.token_url_config?.use_basic_authentication_scheme,
     false,
   );
+  // test with use_basic_authentication_scheme true
   assertStrictEquals(
     exportedManifest.external_auth_providers?.oauth2
       ?.test_provider_with_use_basic_authentication_scheme_true?.options

--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -1346,3 +1346,88 @@ Deno.test("Manifest throws error when Providers with duplicate provider_keys are
     assertStringIncludes(error.message, "OAuth2Provider");
   }
 });
+
+Deno.test("SlackManifest() oauth2 providers get set properly with token_url_config", () => {
+  const providerKey1 = "test_provider_with_token_url_config_unset";
+  const providerKey2 =
+    "test_provider_with_use_basic_authentication_scheme_false";
+  const providerKey3 =
+    "test_provider_with_use_basic_authentication_scheme_true";
+
+  const Provider1 = DefineOAuth2Provider({
+    provider_key: providerKey1,
+    provider_type: Schema.providers.oauth2.CUSTOM,
+    options: {
+      "client_id": "123.456",
+      "scope": ["scope_a", "scope_b"],
+      "token_url_config": {},
+    },
+  });
+
+  const Provider2 = DefineOAuth2Provider({
+    provider_key: providerKey2,
+    provider_type: Schema.providers.oauth2.CUSTOM,
+    options: {
+      "client_id": "123.456",
+      "scope": ["scope_a", "scope_b"],
+      "token_url_config": {
+        "use_basic_authentication_scheme": false,
+      },
+    },
+  });
+
+  const Provider3 = DefineOAuth2Provider({
+    provider_key: providerKey3,
+    provider_type: Schema.providers.oauth2.CUSTOM,
+    options: {
+      "client_id": "123.456",
+      "scope": ["scope_a", "scope_b"],
+      "token_url_config": {
+        "use_basic_authentication_scheme": true,
+      },
+    },
+  });
+
+  const definition: SlackManifestType = {
+    name: "Name",
+    description: "Description",
+    icon: "icon.png",
+    botScopes: [],
+    externalAuthProviders: [Provider1, Provider2, Provider3],
+  };
+  assertEquals(definition.externalAuthProviders, [
+    Provider1,
+    Provider2,
+    Provider3,
+  ]);
+  const Manifest = new SlackManifest(definition);
+  const exportedManifest = Manifest.export();
+
+  assertEquals(exportedManifest.external_auth_providers, {
+    "oauth2": {
+      "test_provider_with_token_url_config_unset": Provider1.export(),
+      "test_provider_with_use_basic_authentication_scheme_false": Provider2
+        .export(),
+      "test_provider_with_use_basic_authentication_scheme_true": Provider3
+        .export(),
+    },
+  });
+  assertStrictEquals(
+    exportedManifest.external_auth_providers?.oauth2
+      ?.test_provider_with_token_url_config_unset?.options
+      ?.token_url_config?.use_basic_authentication_scheme,
+    undefined,
+  );
+  assertStrictEquals(
+    exportedManifest.external_auth_providers?.oauth2
+      ?.test_provider_with_use_basic_authentication_scheme_false?.options
+      ?.token_url_config?.use_basic_authentication_scheme,
+    false,
+  );
+  assertStrictEquals(
+    exportedManifest.external_auth_providers?.oauth2
+      ?.test_provider_with_use_basic_authentication_scheme_true?.options
+      ?.token_url_config?.use_basic_authentication_scheme,
+    true,
+  );
+});

--- a/src/providers/oauth2/types.ts
+++ b/src/providers/oauth2/types.ts
@@ -8,6 +8,11 @@ export type OAuth2ProviderIdentitySchema = {
   };
 };
 
+export type tokenUrlConfigSchema = {
+  /** Default value is false */
+  "use_basic_authentication_scheme"?: boolean;
+};
+
 export type OAuth2ProviderOptions = {
   /** Client id for your provider */
   "client_id": string;
@@ -19,7 +24,10 @@ export type OAuth2ProviderOptions = {
   "authorization_url"?: string;
   /** Token url for your provider. Required for CUSTOM provider types. */
   "token_url"?: string;
-  /** Identity configuration for your provider. Required for CUSTOM provider types. */
+  /** Optional configs for token url. Required for CUSTOM provider types. */
+  "token_url_config"?: tokenUrlConfigSchema;
+  /** Identity configuration for your provider. Required for CUSTOM provider types.
+   * If token_url_config is not present, use_basic_authentication_scheme value is false by default. */
   "identity_config"?: OAuth2ProviderIdentitySchema;
   /** Optional extras dict for authorization url for your provider. Required for CUSTOM provider types. */
   "authorization_url_extras"?: { [key: string]: string };


### PR DESCRIPTION
###  Summary
To support more connectors, 3p auth manifest config requires some more new SDK fields

This PR is to add a new field that helps the connector team unblock creating some more connectors.

`token_url_config : { use_basic_authentication_scheme_scheme : boolean}` to support providers that use this.

More discussions can be found in our slack instance.

closing [this old PR](https://github.com/slackapi/deno-slack-sdk/pull/198) for this.


### Important
Please do not merge it until the web app changes are merged! Thanks!

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).