### PR TITLE
fixing the property

### DIFF
--- a/src/providers/oauth2/oauth2_test.ts
+++ b/src/providers/oauth2/oauth2_test.ts
@@ -192,9 +192,8 @@ Deno.test("SlackManifest() oauth2 providers get set properly with token_url_conf
       "token_url_config": {},
     },
   });
-  // test with use_basic_authentication_scheme false
-  const providerKey2 =
-    "test_provider_with_use_basic_authentication_scheme_false";
+  // test with use_basic_auth_scheme false
+  const providerKey2 = "test_provider_with_use_basic_auth_scheme_false";
   const Provider2 = DefineOAuth2Provider({
     provider_key: providerKey2,
     provider_type: Schema.providers.oauth2.CUSTOM,
@@ -202,13 +201,12 @@ Deno.test("SlackManifest() oauth2 providers get set properly with token_url_conf
       "client_id": "123.456",
       "scope": ["scope_a", "scope_b"],
       "token_url_config": {
-        "use_basic_authentication_scheme": false,
+        "use_basic_auth_scheme": false,
       },
     },
   });
-  // test with use_basic_authentication_scheme true
-  const providerKey3 =
-    "test_provider_with_use_basic_authentication_scheme_true";
+  // test with use_basic_auth_scheme true
+  const providerKey3 = "test_provider_with_use_basic_auth_scheme_true";
   const Provider3 = DefineOAuth2Provider({
     provider_key: providerKey3,
     provider_type: Schema.providers.oauth2.CUSTOM,
@@ -216,7 +214,7 @@ Deno.test("SlackManifest() oauth2 providers get set properly with token_url_conf
       "client_id": "123.456",
       "scope": ["scope_a", "scope_b"],
       "token_url_config": {
-        "use_basic_authentication_scheme": true,
+        "use_basic_auth_scheme": true,
       },
     },
   });
@@ -238,31 +236,31 @@ Deno.test("SlackManifest() oauth2 providers get set properly with token_url_conf
   assertEquals(exportedManifest.external_auth_providers, {
     "oauth2": {
       "test_provider_with_token_url_config_unset": Provider1.export(),
-      "test_provider_with_use_basic_authentication_scheme_false": Provider2
+      "test_provider_with_use_basic_auth_scheme_false": Provider2
         .export(),
-      "test_provider_with_use_basic_authentication_scheme_true": Provider3
+      "test_provider_with_use_basic_auth_scheme_true": Provider3
         .export(),
     },
   });
-  // test with use_basic_authentication_scheme unset
+  // test with use_basic_auth_scheme unset
   assertStrictEquals(
     exportedManifest.external_auth_providers?.oauth2
       ?.test_provider_with_token_url_config_unset?.options
-      ?.token_url_config?.use_basic_authentication_scheme,
+      ?.token_url_config?.use_basic_auth_scheme,
     undefined,
   );
-  // test with use_basic_authentication_scheme false
+  // test with use_basic_auth_scheme false
   assertStrictEquals(
     exportedManifest.external_auth_providers?.oauth2
-      ?.test_provider_with_use_basic_authentication_scheme_false?.options
-      ?.token_url_config?.use_basic_authentication_scheme,
+      ?.test_provider_with_use_basic_auth_scheme_false?.options
+      ?.token_url_config?.use_basic_auth_scheme,
     false,
   );
-  // test with use_basic_authentication_scheme true
+  // test with use_basic_auth_scheme true
   assertStrictEquals(
     exportedManifest.external_auth_providers?.oauth2
-      ?.test_provider_with_use_basic_authentication_scheme_true?.options
-      ?.token_url_config?.use_basic_authentication_scheme,
+      ?.test_provider_with_use_basic_auth_scheme_true?.options
+      ?.token_url_config?.use_basic_auth_scheme,
     true,
   );
 });

--- a/src/providers/oauth2/types.ts
+++ b/src/providers/oauth2/types.ts
@@ -25,7 +25,7 @@ export type OAuth2ProviderIdentitySchema = {
 
 export type tokenUrlConfigSchema = {
   /** Default value is false */
-  "use_basic_authentication_scheme"?: boolean;
+  "use_basic_auth_scheme"?: boolean;
 };
 
 export type OAuth2ProviderOptions = {
@@ -42,7 +42,7 @@ export type OAuth2ProviderOptions = {
   /** Optional configs for token url. Required for CUSTOM provider types. */
   "token_url_config"?: tokenUrlConfigSchema;
   /** Identity configuration for your provider. Required for CUSTOM provider types.
-   * If token_url_config is not present, use_basic_authentication_scheme value is false by default. */
+   * If token_url_config is not present, use_basic_auth_scheme value is false by default. */
   "identity_config"?: OAuth2ProviderIdentitySchema;
   /** Optional extras dict for authorization url for your provider. Required for CUSTOM provider types. */
   "authorization_url_extras"?: { [key: string]: string };


### PR DESCRIPTION
###  Summary
The new field added in the previous PR had a typo.

To support more connectors, 3p auth manifest config requires some more new SDK fields

This PR is to add a new field that helps the connector team unblock creating some more connectors.

`token_url_config : { use_basic_auth_scheme_scheme : boolean}` to support providers that use this.

More discussions can be found in our slack instance.


### Important
Please do not merge it until the web app changes are merged! Thanks!

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).