### PR TITLE
fix(manifest): Strip protocol before feeding just the outgoing domain to the manifest API

### DIFF
--- a/src/manifest/manifest_test.ts
+++ b/src/manifest/manifest_test.ts
@@ -3,7 +3,7 @@ import {
   ISlackManifestRunOnSlack,
   SlackManifestType,
 } from "./types.ts";
-import { Manifest, SlackManifest } from "./mod.ts";
+import { Manifest, SlackManifest, validateOutgoingDomains } from "./mod.ts";
 import {
   DefineDatastore,
   DefineEvent,
@@ -26,6 +26,7 @@ import {
 import { DefineConnector } from "../functions/mod.ts";
 import { InternalSlackTypes } from "../schema/slack/types/custom/mod.ts";
 import { DuplicateCallbackIdError, DuplicateNameError } from "./errors.ts";
+import { assertThrows } from "https://deno.land/std@0.152.0/testing/asserts.ts";
 
 Deno.test("SlackManifestType correctly resolves to a Hosted App when runOnSlack = true", () => {
   const definition: SlackManifestType = {
@@ -1171,4 +1172,67 @@ Deno.test("Manifest throws error when CustomEvents with duplicate name are added
     assertInstanceOf(error, DuplicateNameError);
     assertStringIncludes(error.message, "CustomEvent");
   }
+});
+
+Deno.test("Manifest correctly parses valid domains", () => {
+  const def = {
+    outgoingDomains: [
+      "https://slack.com",
+      "http://salesforce.com",
+      "https://api.slack.com",
+    ],
+  };
+  const expected = ["slack.com", "salesforce.com", "api.slack.com"];
+
+  const definition: SlackManifestType = {
+    runOnSlack: false,
+    name: "test",
+    description: "description",
+    backgroundColor: "#FFF",
+    longDescription:
+      "The book is a roman à clef, rooted in autobiographical incidents. The story follows its protagonist, Raoul Duke, and his attorney, Dr. Gonzo, as they descend on Las Vegas to chase the American Dream...",
+    displayName: "displayName",
+    icon: "icon.png",
+    botScopes: ["channels:history", "chat:write", "commands"],
+  };
+  const manifest = Manifest(definition);
+
+  manifest.outgoing_domains = validateOutgoingDomains(
+    def.outgoingDomains || [],
+  );
+
+  assertEquals(manifest.outgoing_domains, expected);
+});
+
+Deno.test("Manifest throws error for invalid domains", () => {
+  const def = {
+    outgoingDomains: [
+      "slack",
+      "htt*ps://api.slack.com",
+      "https://api slack.com",
+    ],
+  };
+
+  assertThrows(
+    () => {
+      const definition: SlackManifestType = {
+        runOnSlack: false,
+        name: "test",
+        description: "description",
+        backgroundColor: "#FFF",
+        longDescription:
+          "The book is a roman à clef, rooted in autobiographical incidents. The story follows its protagonist, Raoul Duke, and his attorney, Dr. Gonzo, as they descend on Las Vegas to chase the American Dream...",
+        displayName: "displayName",
+        icon: "icon.png",
+        botScopes: ["channels:history", "chat:write", "commands"],
+      };
+      const manifest = Manifest(definition);
+
+      manifest.outgoing_domains = validateOutgoingDomains(
+        def.outgoingDomains || [],
+      );
+    },
+    Error,
+    "Invalid outgoing domain",
+  );
 });

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -32,6 +32,18 @@ export const Manifest = (
   return manifest.export();
 };
 
+export const validateOutgoingDomains = (
+  domains: string[],
+) => {
+  return domains.map((domain) => {
+    try {
+      return new URL(domain).hostname;
+    } catch (e) {
+      throw new Error(`Invalid outgoing domain: ${domain}, error ${e}`);
+    }
+  });
+};
+
 export class SlackManifest {
   constructor(private definition: SlackManifestType) {
     this.registerFeatures();
@@ -132,13 +144,9 @@ export class SlackManifest {
       );
     }
 
-    manifest.outgoing_domains = (def.outgoingDomains || []).map((domain) => {
-      try {
-        return new URL(domain).hostname;
-      } catch (e) {
-        throw new Error(`Invalid outgoing domain: ${domain}, error ${e}`);
-      }
-    });
+    manifest.outgoing_domains = validateOutgoingDomains(
+      def.outgoingDomains || [],
+    );
 
     // Assign remote hosted app properties
     if (manifest.settings.function_runtime === "slack") {

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -37,11 +37,23 @@ export const validateOutgoingDomains = (
 ) => {
   return domains.map((domain) => {
     try {
-      return new URL(domain).hostname;
+      const url = domain.includes("://") ? domain : `http://${domain}`;
+      return new URL(url).hostname;
     } catch (e) {
-      return domain;
+      if (isValidDomain(domain)) {
+        return domain;
+      } else {
+        throw new Error(
+          `Invalid outgoing domain: ${domain}, error ${e}`,
+        );
+      }
     }
   });
+};
+
+const isValidDomain = (domain: string) => {
+  const domainPattern = /^[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}$/;
+  return domainPattern.test(domain);
 };
 
 export class SlackManifest {

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -39,7 +39,7 @@ export const validateOutgoingDomains = (
     try {
       return new URL(domain).hostname;
     } catch (e) {
-      throw new Error(`Invalid outgoing domain: ${domain}, error ${e}`);
+      return domain;
     }
   });
 };

--- a/src/manifest/mod.ts
+++ b/src/manifest/mod.ts
@@ -132,7 +132,13 @@ export class SlackManifest {
       );
     }
 
-    manifest.outgoing_domains = def.outgoingDomains || [];
+    manifest.outgoing_domains = (def.outgoingDomains || []).map((domain) => {
+      try {
+        return new URL(domain).hostname;
+      } catch (e) {
+        throw new Error(`Invalid outgoing domain: ${domain}, error ${e}`);
+      }
+    });
 
     // Assign remote hosted app properties
     if (manifest.settings.function_runtime === "slack") {


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

### Summary

Fixes https://github.com/slackapi/deno-slack-sdk/issues/245

When one or more outgoing domains in the manifest contain the protocol, the protocol is stripped off before feeding just the domain to the manifest API. 

### Testing

- Clone branch
- In a next-gen Slack project, use an invalid outgoing domain name like `http:/example.com` or `ht*tp://example.com` in the `manifest.ts` file 
- Update `import_map.json` on your Slack project to use the local, patched Deno SDK. Example below.
- Run `slack run` to notice that the request fails with the appropriate error.

```
{
  "imports": {
    "deno-slack-sdk/": "/Users/arun/deno-slack-sdk/src/",
    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.1.1/"
  }
}
```

### Special notes

<!-- Any special notes reviewers should be aware of. -->

N/A

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've ran `deno task test` after making the changes.
