### PR TITLE
Use GITHUB_OUTPUT envvar instead of set-output command as the latter is deprecated

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,26 +4,24 @@
 name: Build & Deploy to NPM
 
 on:
-  push:    
-    tags:        
-      - '*.*.*'
-    
+  push:
+    tags:
+      - "*.*.*"
 
 jobs:
-
   build:
     runs-on: macos-latest
-    
+
     steps:
       - name: Actions checkout
         uses: actions/checkout@v3
-      
+
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: latest
           registry-url: https://registry.npmjs.org/
-          
+
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
@@ -31,21 +29,12 @@ jobs:
 
       - name: Get the tag name
         id: get_tag_name
-        run: echo ::set-output name=TAG::${GITHUB_REF#refs/*/}
-        
+        run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
       - name: Run build_npm.ts
         run: deno run -A scripts/build_npm.ts ${{steps.get_tag_name.outputs.TAG}}
-        
-      - name: Publish to NPM    
+
+      - name: Publish to NPM
         run: cd npm && npm publish --access=public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}                 
-      
-        
-         
-    
-    
-
-      
-
-
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### Summary

`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

### Testing

- I think the next publish action should successfully go through?

### Special notes

I have scanned all repositories owned by `slackapi` (thanks to [gh-clone-org extension](https://github.com/matt-bartel/gh-clone-org) from [this issue](https://github.com/cli/cli/issues/2450#issuecomment-978093661)) and there is only one instance of usage. 

It's `set-output` on the `npm-publish` workflow for `deno-slack-sdk` repository. 

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've ran `deno task test` after making the changes.
