### PR TITLE
Upgrading deno-slack-api to v2.4.0 (support for `all_resources` event triggers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .coverage
+.vim
 lcov.info
 npm/

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,5 @@
-export { SlackAPI } from "https://deno.land/x/deno_slack_api@2.3.2/mod.ts";
+export { SlackAPI } from "https://deno.land/x/deno_slack_api@2.4.0/mod.ts";
 export type {
   SlackAPIClient,
   Trigger,
-} from "https://deno.land/x/deno_slack_api@2.3.2/types.ts";
+} from "https://deno.land/x/deno_slack_api@2.4.0/types.ts";


### PR DESCRIPTION
Fixes #222 and #298.