### PR TITLE
Fix typo in README.md

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -215,6 +215,6 @@ assistance working through your issue:
 
 ## Contributing
 
-Contributions are more then welcome. Please look at the
+Contributions are more than welcome. Please look at the
 [contributing guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md)
 for more info!


### PR DESCRIPTION
### Summary

The sentence:

> Contributions are more **then** welcome.

Should read:

> Contributions are more **than** welcome.

### Testing

N/A.

### Special notes

N/A.

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've ran `deno task test` after making the changes.
