### PR TITLE
Bump deno_slack_api to 2.7.1

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,5 @@
-export { SlackAPI } from "https://deno.land/x/deno_slack_api@2.7.0/mod.ts";
+export { SlackAPI } from "https://deno.land/x/deno_slack_api@2.7.1/mod.ts";
 export type {
   SlackAPIClient,
   Trigger,
-} from "https://deno.land/x/deno_slack_api@2.7.0/types.ts";
+} from "https://deno.land/x/deno_slack_api@2.7.1/types.ts";


### PR DESCRIPTION
Fixes an issue with the API client proxying calls to `then`; https://github.com/slackapi/deno-slack-api/releases/tag/2.7.1