### PR TITLE
chore: bump the api dependency version

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -10,7 +10,7 @@
       ".github/maintainers_guide.md",
       ".github/CONTRIBUTING.md"
     ],
-    "exclude": ["src/schema/slack/functions/_scripts/functions.json"]
+    "exclude": ["src/schema/slack/functions/_scripts/functions.json"],
     "semiColons": true,
     "indentWidth": 2,
     "lineWidth": 80,
@@ -20,10 +20,7 @@
   },
   "lint": {
     "include": ["src", "tests", "scripts"],
-    "exclude": [
-      "src/schema/slack/functions/_scripts/functions.json",
-      "**/*.md"
-    ]
+    "exclude": ["src/schema/slack/functions/_scripts/functions.json", "**/*.md"]
   },
   "tasks": {
     "test": "deno fmt --check && deno lint && deno bundle src/mod.ts && deno test --allow-read --allow-run --parallel src/ tests/",

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,5 @@
-export { SlackAPI } from "https://deno.land/x/deno_slack_api@2.7.1/mod.ts";
+export { SlackAPI } from "https://deno.land/x/deno_slack_api@2.8.0/mod.ts";
 export type {
   SlackAPIClient,
   Trigger,
-} from "https://deno.land/x/deno_slack_api@2.7.1/types.ts";
+} from "https://deno.land/x/deno_slack_api@2.8.0/types.ts";


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Friendly reminder: this project is open sourced, the internet can see it,
make sure all the info/links shared in this pull request are public information.
-->

### Summary

This PR bumps the deno-slack-sdk version to the latest

### Testing

N/A

### Special notes

N/A

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've ran `deno task test` after making the changes.
