### PR TITLE
feat: add salesforce record id type

### DIFF
--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -80,6 +80,7 @@ type FunctionInputRuntimeType<
       | typeof SlackSchemaTypes.canvas_id
       | typeof SlackSchemaTypes.canvas_template_id
       | typeof SlackSchemaTypes.date
+      | typeof SlackSchemaTypes.salesforce_record_id
       | typeof SlackSchemaTypes.message_ts ? string
     : Param["type"] extends
       | typeof SchemaTypes.integer
@@ -96,10 +97,9 @@ type FunctionInputRuntimeType<
         infer RP
       > ? TypedObjectFunctionInputRuntimeType<P, RP, Param>
       : UnknownRuntimeType
-    : Param["type"] extends typeof SlackSchemaTypes.rich_text
-      ? UnknownRuntimeType
-    : Param["type"] extends typeof SlackSchemaTypes.expanded_rich_text
-      ? UnknownRuntimeType
+    : Param["type"] extends
+      | typeof SlackSchemaTypes.rich_text
+      | typeof SlackSchemaTypes.expanded_rich_text ? UnknownRuntimeType
     : UnknownRuntimeType;
 
 // deno-lint-ignore no-explicit-any

--- a/src/schema/slack/types/mod.ts
+++ b/src/schema/slack/types/mod.ts
@@ -11,6 +11,7 @@ const SlackPrimitiveTypes = {
   message_ts: "slack#/types/message_ts",
   oauth2: "slack#/types/credential/oauth2",
   rich_text: "slack#/types/rich_text",
+  salesforce_record_id: "slack#/types/salesforce_record_id",
   team_id: "slack#/types/team_id",
   timestamp: "slack#/types/timestamp",
   user_id: "slack#/types/user_id",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Friendly reminder: this project is open sourced, the internet can see it,
make sure all the info/links shared in this pull request are public information.
-->

### Summary

This PR aims to add a new hidden type `slack#/types/salesforce_record_id`

This type behaves as a string, similar to other `id` types like `user_is`, `canvas_id` etc ...

### Special notes

This aims to unblock https://github.com/slackapi/deno-slack-hub/pull/66

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've ran `deno task test` after making the changes.
