### PR TITLE
fix: allow non import prefix

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -20,7 +20,13 @@
   },
   "lint": {
     "include": ["src", "tests", "scripts"],
-    "exclude": ["src/schema/slack/functions/_scripts/functions.json", "**/*.md"]
+    "exclude": [
+      "src/schema/slack/functions/_scripts/functions.json",
+      "**/*.md"
+    ],
+    "rules": {
+      "exclude": ["no-import-prefix"]
+    }
   },
   "tasks": {
     "test": "deno fmt --check && deno lint && deno run --allow-run --allow-env --allow-read scripts/bundle.ts && deno test --allow-read --allow-run --parallel src/ tests/",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Friendly reminder: this project is open sourced, the internet can see it,
make sure all the info/links shared in this pull request are public information.
-->

### Summary

This PR configures the project to allow [non import prefixes](https://docs.deno.com/lint/rules/no-import-prefix/), non import prefixes are critical to this project

### Testing

The CI is passing

### Special notes

In the future we may want to import dependencies through the `deno.jsonc` file similar to how our [templates](https://github.com/slack-samples/deno-starter-template/blob/main/deno.jsonc) do. We will need to investigate if this is a breaking change.

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've ran `deno task test` after making the changes.
